### PR TITLE
Make dependency on `parking_lot` optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ readme = "README.md"
 exclude = ["fuzz"]
 
 [features]
-default = ["dep:ahash"]
+default = ["ahash", "parking_lot"]
 
 [dependencies]
 ahash = { optional = true, version = "0.8" }
 hashbrown = { version = "0.13", default-features = false, features = ["raw", "inline-more"] }
-parking_lot = "0.12"
+parking_lot = { optional = true, version = "0.12" }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,12 @@
 //! By default the crate uses [ahash](https://crates.io/crates/ahash), which is enabled (by default) via
 //! a crate feature with the same name. If the `ahash` feature is disabled the crate defaults to the std lib
 //! implementation instead (currently Siphash13). Note that a custom hasher can also be provided if desirable.
+//!
+//! # Synchronization primitives
+//!
+//! By default the crate uses [parking_lot](https://crates.io/crates/parking_lot), which is enabled (by default) via
+//! a crate feature with the same name. If the `parking_lot` feature is disabled the crate defaults to the std lib
+//! implementation instead.
 
 use std::num::NonZeroU32;
 
@@ -36,6 +42,7 @@ pub mod linked_slab;
 mod options;
 #[cfg(fuzzing)]
 pub mod options;
+mod rw_lock;
 mod shard;
 /// Concurrent cache variants that can be used from multiple threads.
 pub mod sync;

--- a/src/rw_lock.rs
+++ b/src/rw_lock.rs
@@ -1,0 +1,140 @@
+use std::ops::{Deref, DerefMut};
+
+#[cfg(feature = "parking_lot")]
+type InnerRwLock<T> = parking_lot::RwLock<T>;
+#[cfg(not(feature = "parking_lot"))]
+type InnerRwLock<T> = std::sync::RwLock<T>;
+
+#[cfg(feature = "parking_lot")]
+type InnerRwLockReadGuard<'rwlock, T> = parking_lot::RwLockReadGuard<'rwlock, T>;
+#[cfg(not(feature = "parking_lot"))]
+type InnerRwLockReadGuard<'rwlock, T> = std::sync::RwLockReadGuard<'rwlock, T>;
+
+#[cfg(feature = "parking_lot")]
+type InnerRwLockWriteGuard<'rwlock, T> = parking_lot::RwLockWriteGuard<'rwlock, T>;
+#[cfg(not(feature = "parking_lot"))]
+type InnerRwLockWriteGuard<'rwlock, T> = std::sync::RwLockWriteGuard<'rwlock, T>;
+
+/// A reader-writer lock.
+///
+/// This type of lock allows a number of readers or at most one writer at any
+/// point in time. The write portion of this lock typically allows modification
+/// of the underlying data (exclusive access) and the read portion of this lock
+/// typically allows for read-only access (shared access).
+///
+/// In comparison, a [`Mutex`] does not distinguish between readers or writers
+/// that acquire the lock, therefore blocking any threads waiting for the lock to
+/// become available. An `RwLock` will allow any number of readers to acquire the
+/// lock as long as a writer is not holding the lock.
+///
+/// The type parameter `T` represents the data that this lock protects. It is
+/// required that `T` satisfies [`Send`] to be shared across threads and
+/// [`Sync`] to allow concurrent access through readers. The RAII guards
+/// returned from the locking methods implement [`Deref`] (and [`DerefMut`]
+/// for the `write` methods) to allow access to the content of the lock.
+///
+/// # Poisoning
+///
+/// An `RwLock` might become poisoned on a panic. Note, however, that an `RwLock`
+/// may only be poisoned if a panic occurs while it is locked exclusively (write
+/// mode). If a panic occurs in any reader, then the lock will not be poisoned.
+#[repr(transparent)]
+pub struct RwLock<T: ?Sized>(InnerRwLock<T>);
+
+/// RAII structure used to release the shared read access of a lock when dropped.
+#[repr(transparent)]
+#[must_use = "if unused the RwLock will immediately unlock"]
+pub struct RwLockReadGuard<'rwlock, T: ?Sized>(InnerRwLockReadGuard<'rwlock, T>);
+
+/// RAII structure used to release the exclusive write access of a lock when dropped.
+#[repr(transparent)]
+#[must_use = "if unused the RwLock will immediately unlock"]
+pub struct RwLockWriteGuard<'rwlock, T: ?Sized>(InnerRwLockWriteGuard<'rwlock, T>);
+
+impl<T> RwLock<T> {
+	/// Creates a new instance of an `RwLock<T>` which is unlocked.
+	pub const fn new(t: T) -> Self {
+		Self(InnerRwLock::new(t))
+	}
+}
+
+impl<T: ?Sized> RwLock<T> {
+	/// Locks this `RwLock` with shared read access, blocking the current thread
+	/// until it can be acquired.
+	///
+	/// The calling thread will be blocked until there are no more writers which
+	/// hold the lock. There may be other readers currently inside the lock when
+	/// this method returns. This method does not provide any guarantees with
+	/// respect to the ordering of whether contentious readers or writers will
+	/// acquire the lock first.
+	///
+	/// Returns an RAII guard which will release this thread's shared access
+	/// once it is dropped.
+	///
+	/// # Panics
+	///
+	/// This function might panic when called if the lock is already held by the
+	/// current thread, or if the `RwLock` is poisoned. An `RwLock` might be
+	/// poisoned whenever a writer panics while holding an exclusive lock.
+	/// Implementations are not required to implement poisoning.
+	#[inline]
+	pub fn read(&self) -> RwLockReadGuard<'_, T> {
+		RwLockReadGuard({
+			#[cfg(feature = "parking_lot")]
+			{
+				self.0.read()
+			}
+			#[cfg(not(feature = "parking_lot"))]
+			self.0.read().unwrap()
+		})
+	}
+
+	/// Locks this `RwLock` with exclusive write access, blocking the current
+	/// thread until it can be acquired.
+	///
+	/// This function will not return while other writers or other readers
+	/// currently have access to the lock.
+	///
+	/// Returns an RAII guard which will drop the write access of this `RwLock`
+	/// when dropped.
+	///
+	/// # Panics
+	///
+	/// This function might panic when called if the lock is already held by the
+	/// current thread, or if the `RwLock` is poisoned. An `RwLock` might be
+	/// poisoned whenever a writer panics while holding an exclusive lock.
+	/// Implementations are not required to implement poisoning.
+	#[inline]
+	pub fn write(&self) -> RwLockWriteGuard<'_, T> {
+		RwLockWriteGuard({
+			#[cfg(feature = "parking_lot")]
+			{
+				self.0.write()
+			}
+			#[cfg(not(feature = "parking_lot"))]
+			self.0.write().unwrap()
+		})
+	}
+}
+
+impl<T: ?Sized> Deref for RwLockReadGuard<'_, T> {
+	type Target = T;
+
+	fn deref(&self) -> &Self::Target {
+		&self.0
+	}
+}
+
+impl<T: ?Sized> Deref for RwLockWriteGuard<'_, T> {
+	type Target = T;
+
+	fn deref(&self) -> &Self::Target {
+		&self.0
+	}
+}
+
+impl<T: ?Sized> DerefMut for RwLockWriteGuard<'_, T> {
+	fn deref_mut(&mut self) -> &mut Self::Target {
+		&mut self.0
+	}
+}

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,9 +1,9 @@
 use crate::{
     options::{Options, OptionsBuilder},
+    rw_lock::RwLock,
     shard::KQCacheShard,
     DefaultHashBuilder, UnitWeighter, Weighter,
 };
-use parking_lot::RwLock;
 use std::{
     borrow::Borrow,
     hash::{BuildHasher, Hash, Hasher},


### PR DESCRIPTION
Resolves #5 by marking the dependency on `parking_lot` as optional, with the possibility to turn it off by disabling the default crate features.

The [newtype pattern](https://rust-unofficial.github.io/patterns/patterns/behavioural/newtype.html) was central to this change, allowing both `std` and `parking_lot` `RwLock` types to be used under the same internal interface without any changes to existing code. The new `RwLock` wrapper type has been defined as potentially (but not necessarily) poisonable and as panicking when poisoned, which is adequate for the purposes of this crate.

In addition, the crate docs have been updated to mention this new optional feature.