### PR TITLE
Return evicted values to user

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,11 @@ default = ["ahash", "parking_lot"]
 
 [dependencies]
 ahash = { optional = true, version = "0.8" }
-hashbrown = { version = "0.13", default-features = false, features = ["raw", "inline-more"] }
+hashbrown = { version = "0.14", default-features = false, features = ["raw", "inline-more"] }
 parking_lot = { optional = true, version = "0.12" }
 
 [dev-dependencies]
-criterion = "0.4"
+criterion = "0.5"
 rand = { version = "0.8", features = ["small_rng"] }
 rand_distr = "0.4"
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quick_cache"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Lightweight and high performance concurrent cache"
 repository = "https://github.com/arthurprs/quick-cache"

--- a/src/shard.rs
+++ b/src/shard.rs
@@ -40,9 +40,9 @@ enum ResidentState {
 
 #[derive(Debug)]
 pub struct Resident<Key, Qey, Val> {
-    key: Key,
-    qey: Qey,
-    value: Val,
+    pub(crate) key: Key,
+    pub(crate) qey: Qey,
+    pub(crate) value: Val,
     state: ResidentState,
     referenced: AtomicBool,
 }


### PR DESCRIPTION
I am currently working on a DBMS and consider this library as a good replacement for a self-written buffer pool. But at the moment there aren't alternative functions in those places where entry eviction can occur.

I added the suffix `_evict` to such functions so as not to violate the public interface. I still have questions about the name of such suffix, but there are no other ideas yet.

Also bumped version to `0.3.1`, according to semver, and updated dependencies.