### PR TITLE
Add new apis to unsync cache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quick_cache"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 description = "Lightweight and high performance concurrent cache"
 repository = "https://github.com/arthurprs/quick-cache"
@@ -10,18 +10,19 @@ keywords = ["lru", "concurrent", "cache"]
 categories = ["caching", "concurrency", "data-structures"]
 readme = "README.md"
 exclude = ["fuzz"]
-rust-version = "1.63"
+rust-version = "1.71"
 
 [features]
 default = ["ahash", "parking_lot"]
 shuttle = ["dep:shuttle"]
+stats = []
 
 [dependencies]
-ahash = { optional = true, version = "0.8" }
+ahash = { optional = true, version = "0.8.10" }
 equivalent = "1.0.1"
 hashbrown = { version = "0.14", default-features = false, features = ["raw", "inline-more"] }
 parking_lot = { optional = true, version = "0.12" }
-shuttle = { version = "0.6", optional = true }
+shuttle = { version = "0.7", optional = true }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Lightweight and high performance concurrent cache optimized for low cache overhe
 * Atomic operations with `get_or_insert` and `get_value_or_guard` functions
 * Atomic async operations with `get_or_insert_async` and `get_value_or_guard_async` functions
 * Doesn't use background threads
-* One trivially verifiable usage of unsafe
+* Only trivially verifiable usages of unsafe
 * Small dependency tree
 
 The implementation is optimized for use cases where the cache access times and overhead can add up to be a significant cost.

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,7 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use quick_cache::sync::Cache;
 use rand::prelude::*;
-use rand::rngs::SmallRng;
 use rand_distr::Zipf;
 
 pub fn r_benchmark(c: &mut Criterion) {

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "quick_cache"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "ahash",
  "equivalent",

--- a/fuzz/fuzz_targets/fuzz_cache.rs
+++ b/fuzz/fuzz_targets/fuzz_cache.rs
@@ -4,7 +4,10 @@ use std::time::Duration;
 use ahash::{HashMap, HashSet};
 use arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
-use quick_cache::{sync::Cache, GuardResult, Lifecycle, OptionsBuilder, Weighter};
+use quick_cache::{
+    sync::{Cache, GuardResult},
+    Lifecycle, OptionsBuilder, Weighter,
+};
 
 #[derive(Clone)]
 struct MyWeighter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@
 //! By default the crate uses [parking_lot](https://crates.io/crates/parking_lot), which is enabled (by default) via
 //! a crate feature with the same name. If the `parking_lot` feature is disabled the crate defaults to the std lib
 //! implementation instead.
+#![allow(clippy::type_complexity)]
 
 #[cfg(not(fuzzing))]
 mod linked_slab;
@@ -59,13 +60,13 @@ pub mod linked_slab;
 mod options;
 #[cfg(fuzzing)]
 pub mod options;
-mod placeholder;
 #[cfg(not(feature = "shuttle"))]
 mod rw_lock;
 mod shard;
 mod shim;
 /// Concurrent cache variants that can be used from multiple threads.
 pub mod sync;
+mod sync_placeholder;
 /// Non-concurrent cache variants.
 pub mod unsync;
 pub use equivalent::Equivalent;
@@ -74,7 +75,6 @@ pub use equivalent::Equivalent;
 mod shuttle_tests;
 
 pub use options::{Options, OptionsBuilder};
-pub use placeholder::{GuardResult, PlaceholderGuard};
 pub use shard::RefMut;
 
 #[cfg(feature = "ahash")]
@@ -274,6 +274,7 @@ mod tests {
 
     #[test]
     fn test_value_or_guard() {
+        use crate::sync::*;
         use rand::prelude::*;
         for _i in 0..2000 {
             dbg!(_i);

--- a/src/linked_slab.rs
+++ b/src/linked_slab.rs
@@ -71,6 +71,7 @@ impl<T> LinkedSlab<T> {
             debug_assert!(entry.item.is_none());
             entry.item = Some(item);
         } else {
+            debug_assert_eq!(idx, self.entries.len());
             self.next_free = Token::new(token.get().wrapping_add(1)).expect("Capacity overflow");
             self.entries.push(Entry {
                 next: token,

--- a/src/shuttle_tests.rs
+++ b/src/shuttle_tests.rs
@@ -3,7 +3,7 @@ use crate::{
         sync::{self, atomic, Arc},
         thread,
     },
-    GuardResult,
+    sync::GuardResult,
 };
 use std::{future::Future, task::Poll, time::Duration};
 


### PR DESCRIPTION
Changes
* Abstract placeholder to allow usage in both unsync and sync cache
* Add new apis to usync cache.
* Put hits/misses functions behind an optional cargo feature named `stats`.
* Don't eagerly adjust hot section of the cache, this improves eviction performance slightly.
* Slightly code paths using `search_resident`.
* Extract overweight item insertion code paths to cold functions.