### PR TITLE
Adjust hot/cold and reduce contention on highly skewed workloads

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quick_cache"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "Lightweight and high performance concurrent cache"
 repository = "https://github.com/arthurprs/quick-cache"

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,4 +1,4 @@
-pub const DEFAULT_HOT_ALLOCATION: f64 = 0.99;
+pub const DEFAULT_HOT_ALLOCATION: f64 = 0.97;
 pub const DEFAULT_GHOST_ALLOCATION: f64 = 0.5;
 
 /// Cache options. Built with [OptionsBuilder].
@@ -88,7 +88,7 @@ impl OptionsBuilder {
     /// lowering this setting. In practice the useful ranges are between 50% to 99%
     /// (usually on the higher side).
     ///
-    /// Defaults to: `0.99` (99%).
+    /// Defaults to: `0.97` (97%).
     #[inline]
     pub fn hot_allocation(&mut self, hot_allocation: f64) -> &mut Self {
         assert!(


### PR DESCRIPTION
- Adopt actual frequency counters, which makes the cache slightly less dependent on large hot allocations. This allows decreasing the default hot allocation from 99% to 97% with more wins than loses on well known traces. This setting should be more forgiving in practice.
- Avoid touching the reference bits whenever possible, this can significantly decrease contention on highly skewed workloads.