### PR TITLE
Switch to u64 weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ use quick_cache::{Weighter, sync::Cache};
 struct StringWeighter;
 
 impl Weighter<u64, String> for StringWeighter {
-    fn weight(&self, _key: &u64, val: &String) -> u32 {
+    fn weight(&self, _key: &u64, val: &String) -> u64 {
         // Be cautions out about zero weights!
-        val.len().clamp(1, u32::MAX as usize) as u32
+        val.len() as u64
     }
 }
 

--- a/examples/custom_weight.rs
+++ b/examples/custom_weight.rs
@@ -4,9 +4,9 @@ use quick_cache::{sync::Cache, Weighter};
 struct StringWeighter;
 
 impl Weighter<u64, String> for StringWeighter {
-    fn weight(&self, _key: &u64, val: &String) -> u32 {
+    fn weight(&self, _key: &u64, val: &String) -> u64 {
         // Be cautions out about zero weights!
-        val.len().clamp(1, u32::MAX as usize) as u32
+        val.len() as u64
     }
 }
 

--- a/fuzz/fuzz_targets/fuzz_cache.rs
+++ b/fuzz/fuzz_targets/fuzz_cache.rs
@@ -16,8 +16,8 @@ struct MyWeighter;
 struct MyLifecycle;
 
 impl Weighter<u16, (u16, u16)> for MyWeighter {
-    fn weight(&self, _key: &u16, val: &(u16, u16)) -> u32 {
-        val.1 as u32
+    fn weight(&self, _key: &u16, val: &(u16, u16)) -> u64 {
+        val.1 as u64
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,9 +93,9 @@ pub type DefaultHashBuilder = std::collections::hash_map::RandomState;
 /// struct StringWeighter;
 ///
 /// impl Weighter<u64, String> for StringWeighter {
-///     fn weight(&self, _key: &u64, val: &String) -> u32 {
+///     fn weight(&self, _key: &u64, val: &String) -> u64 {
 ///         // Be cautions out about zero weights!
-///         val.len().clamp(1, u32::MAX as usize) as u32
+///         val.len() as u64
 ///     }
 /// }
 ///
@@ -114,7 +114,10 @@ pub trait Weighter<Key, Val> {
     ///
     /// Note that this it's undefined behavior for a cache item to change its weight.
     /// The only exception to this is when Lifecycle::before_evict is called.
-    fn weight(&self, key: &Key, val: &Val) -> u32;
+    ///
+    /// It's also undefined behavior in release mode if summing of weights overflow,
+    /// although this is unlikely to be a problem in pratice.
+    fn weight(&self, key: &Key, val: &Val) -> u64;
 }
 
 /// Each cache entry weights exactly `1` unit of weight.
@@ -123,7 +126,7 @@ pub struct UnitWeighter;
 
 impl<Key, Val> Weighter<Key, Val> for UnitWeighter {
     #[inline]
-    fn weight(&self, _key: &Key, _val: &Val) -> u32 {
+    fn weight(&self, _key: &Key, _val: &Val) -> u64 {
         1
     }
 }
@@ -190,8 +193,8 @@ mod tests {
         struct StringWeighter;
 
         impl Weighter<u64, String> for StringWeighter {
-            fn weight(&self, _key: &u64, val: &String) -> u32 {
-                val.len().clamp(1, u32::MAX as usize) as u32
+            fn weight(&self, _key: &u64, val: &String) -> u64 {
+                val.len() as u64
             }
         }
 


### PR DESCRIPTION
This has the drawback of allowing for the possibility of weight overflows, but that's highly unlikely to be a problem in practice.

If it happens (and overflow checks disabled) it might cause the cache to get confused (e.g. allowing more items or infinite eviction loops) but it cannot lead to memory unsafety.

Closes #25