### PR TITLE
Revert "Optimize handling of zero weight items"

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "quick_cache"
-version = "0.5.1"
+version = "0.5.0"
 dependencies = [
  "ahash",
  "equivalent",

--- a/fuzz/fuzz_targets/fuzz_linked_slab.rs
+++ b/fuzz/fuzz_targets/fuzz_linked_slab.rs
@@ -30,16 +30,14 @@ fuzz_target!(|ops: Vec<Op>| {
                         }
                         Some((_, &next_token)) => {
                             // insert i before next_token, which is the token for a key > i
-                            let new_token = slab.insert(i);
-                            slab.link(new_token, Some(next_token));
+                            let new_token = slab.insert(i, Some(next_token));
                             model.insert(i, new_token);
                         }
                         None => {
                             // insert i before the very first token,
                             // which is the same as inserting at the end
                             let first_token = model.values().next().copied();
-                            let new_token = slab.insert(i);
-                            slab.link(new_token, first_token);
+                            let new_token = slab.insert(i, first_token);
                             model.insert(i, new_token);
                         }
                     }

--- a/src/linked_slab.rs
+++ b/src/linked_slab.rs
@@ -55,12 +55,12 @@ impl<T> LinkedSlab<T> {
         }
     }
 
-    /// Inserts a new entry in the list.
-    /// Initially, the item will belong to a list only containing itself.
+    /// Inserts a new entry in the list, link it before `head`.
+    /// If `head` is not set the item will belong to a list only containing itself.
     ///
     /// # Panics
     /// Panics if number of items exceed `u32::MAX - 1`.
-    pub fn insert(&mut self, item: T) -> Token {
+    pub fn insert(&mut self, item: T, head: Option<Token>) -> Token {
         let token = self.next_free;
         // eprintln!("linkedslab::insert token {token} head {head:?}");
         let idx = (token.get() - 1) as usize;
@@ -79,6 +79,7 @@ impl<T> LinkedSlab<T> {
                 item: Some(item),
             });
         }
+        self.link(token, head);
         token
     }
 
@@ -134,8 +135,8 @@ impl<T> LinkedSlab<T> {
 
         let entry = &mut self.entries[(idx.get() - 1) as usize];
         debug_assert!(entry.item.is_some());
-        debug_assert_eq!(entry.next, idx);
-        debug_assert_eq!(entry.prev, idx);
+        assert_eq!(entry.next, idx);
+        assert_eq!(entry.prev, idx);
         (entry.prev, entry.next) = (prev, next);
     }
 

--- a/src/shard.rs
+++ b/src/shard.rs
@@ -513,62 +513,74 @@ impl<
     fn advance_cold(&mut self, lcs: &mut L::RequestState) {
         debug_assert_ne!(self.num_cold + self.num_hot, 0);
         debug_assert_ne!(self.weight_cold + self.weight_hot, 0);
+        loop {
+            let idx = if let Some(idx) = self.cold_head {
+                idx
+            } else {
+                self.advance_hot(lcs);
+                return;
+            };
+            let (entry, next) = self.entries.get_mut(idx).unwrap();
+            let Entry::Resident(resident) = entry else {
+                unreachable!()
+            };
+            debug_assert_eq!(resident.state, ResidentState::Cold);
+            if *resident.referenced.get_mut() != 0 {
+                resident.state = ResidentState::Hot;
+                let weight = self.weighter.weight(&resident.key, &resident.value);
+                self.weight_hot += weight;
+                self.weight_cold -= weight;
+                self.num_hot += 1;
+                self.num_cold -= 1;
+                Self::relink(
+                    &mut self.entries,
+                    idx,
+                    &mut self.cold_head,
+                    &mut self.hot_head,
+                );
+                // evict from hot if overweight
+                while self.weight_hot > self.weight_target_hot {
+                    self.advance_hot(lcs);
+                }
+                return;
+            }
 
-        let idx = if let Some(idx) = self.cold_head {
-            idx
-        } else {
-            self.advance_hot(lcs);
-            return;
-        };
-        let (entry, _) = self.entries.get_mut(idx).unwrap();
-        let Entry::Resident(resident) = entry else {
-            unreachable!()
-        };
-        debug_assert_eq!(resident.state, ResidentState::Cold);
-        if *resident.referenced.get_mut() != 0 {
-            resident.state = ResidentState::Hot;
             let weight = self.weighter.weight(&resident.key, &resident.value);
-            self.weight_hot += weight;
+            if weight == 0 {
+                if self.weight_cold == 0 {
+                    self.advance_hot(lcs);
+                    return;
+                } else {
+                    self.cold_head = Some(next);
+                    continue;
+                }
+            }
             self.weight_cold -= weight;
-            self.num_hot += 1;
-            self.num_cold -= 1;
+            self.lifecycle
+                .before_evict(lcs, &resident.key, &mut resident.value);
+            if self.weighter.weight(&resident.key, &resident.value) == 0 {
+                self.cold_head = Some(next);
+                return;
+            }
+            let hash = Self::hash_static(&self.hash_builder, &resident.key);
+            let Entry::Resident(evicted) = mem::replace(entry, Entry::Ghost(hash)) else {
+                unreachable!()
+            };
             Self::relink(
                 &mut self.entries,
                 idx,
                 &mut self.cold_head,
-                &mut self.hot_head,
+                &mut self.ghost_head,
             );
-            // evict from hot if overweight
-            while self.weight_hot > self.weight_target_hot {
-                self.advance_hot(lcs);
+            self.num_cold -= 1;
+            self.num_non_resident += 1;
+            // evict from ghost if oversized
+            if self.num_non_resident > self.capacity_non_resident {
+                self.advance_ghost();
             }
+            self.lifecycle.on_evict(lcs, evicted.key, evicted.value);
             return;
         }
-
-        self.weight_cold -= self.weighter.weight(&resident.key, &resident.value);
-        self.lifecycle
-            .before_evict(lcs, &resident.key, &mut resident.value);
-        if self.weighter.weight(&resident.key, &resident.value) == 0 {
-            self.cold_head = self.entries.unlink(idx);
-            return;
-        }
-        let hash = Self::hash_static(&self.hash_builder, &resident.key);
-        let Entry::Resident(evicted) = mem::replace(entry, Entry::Ghost(hash)) else {
-            unreachable!()
-        };
-        Self::relink(
-            &mut self.entries,
-            idx,
-            &mut self.cold_head,
-            &mut self.ghost_head,
-        );
-        self.num_cold -= 1;
-        self.num_non_resident += 1;
-        // evict from ghost if oversized
-        if self.num_non_resident > self.capacity_non_resident {
-            self.advance_ghost();
-        }
-        self.lifecycle.on_evict(lcs, evicted.key, evicted.value);
     }
 
     /// Advance hot ring evicting entries.
@@ -589,11 +601,16 @@ impl<
                 self.hot_head = Some(next);
                 continue;
             }
-            self.weight_hot -= self.weighter.weight(&resident.key, &resident.value);
+            let weight = self.weighter.weight(&resident.key, &resident.value);
+            if weight == 0 {
+                self.hot_head = Some(next);
+                continue;
+            }
+            self.weight_hot -= weight;
             self.lifecycle
                 .before_evict(lcs, &resident.key, &mut resident.value);
             if self.weighter.weight(&resident.key, &resident.value) == 0 {
-                self.hot_head = self.entries.unlink(idx);
+                self.hot_head = Some(next);
             } else {
                 self.num_hot -= 1;
                 let hash = Self::hash_static(&self.hash_builder, &resident.key);
@@ -669,20 +686,12 @@ impl<
             Entry::Resident(evicted) => {
                 debug_assert_eq!(evicted.state, enter_state);
                 let evicted_weight = self.weighter.weight(&evicted.key, &evicted.value);
-                let list_head = if enter_state == ResidentState::Hot {
+                if enter_state == ResidentState::Hot {
                     self.weight_hot -= evicted_weight;
                     self.weight_hot += weight;
-                    &mut self.hot_head
                 } else {
                     self.weight_cold -= evicted_weight;
                     self.weight_cold += weight;
-                    &mut self.cold_head
-                };
-                if evicted_weight == 0 && weight != 0 {
-                    self.entries.link(idx, *list_head);
-                    list_head.get_or_insert(idx);
-                } else if evicted_weight != 0 && weight == 0 {
-                    *list_head = self.entries.unlink(idx);
                 }
                 self.lifecycle.on_evict(lcs, evicted.key, evicted.value);
             }
@@ -690,16 +699,11 @@ impl<
                 self.weight_hot += weight;
                 self.num_hot += 1;
                 self.num_non_resident -= 1;
-                let mut _tmp = None;
                 Self::relink(
                     &mut self.entries,
                     idx,
                     &mut self.ghost_head,
-                    if weight != 0 {
-                        &mut self.hot_head
-                    } else {
-                        &mut _tmp
-                    },
+                    &mut self.hot_head,
                 );
             }
             Entry::Placeholder(_) => {
@@ -712,10 +716,8 @@ impl<
                     self.weight_cold += weight;
                     &mut self.cold_head
                 };
-                if weight != 0 {
-                    self.entries.link(idx, *list_head);
-                    list_head.get_or_insert(idx);
-                }
+                self.entries.link(idx, *list_head);
+                list_head.get_or_insert(idx);
             }
         }
 
@@ -812,13 +814,11 @@ impl<
             self.weight_cold += weight;
             &mut self.cold_head
         };
+        self.entries.link(placeholder.idx(), *list_head);
+        list_head.get_or_insert(placeholder.idx());
 
-        if weight != 0 {
-            self.entries.link(placeholder.idx(), *list_head);
-            list_head.get_or_insert(placeholder.idx());
-            while self.weight_hot + self.weight_cold > self.weight_capacity {
-                self.advance_cold(lcs);
-            }
+        while self.weight_hot + self.weight_cold > self.weight_capacity {
+            self.advance_cold(lcs);
         }
 
         Ok(())
@@ -885,16 +885,16 @@ impl<
             self.weight_cold += weight;
             (ResidentState::Cold, &mut self.cold_head)
         };
-        let idx = self.entries.insert(Entry::Resident(Resident {
-            key,
-            value,
-            state,
-            referenced: Default::default(),
-        }));
-        if weight != 0 {
-            self.entries.link(idx, *list_head);
-            list_head.get_or_insert(idx);
-        }
+        let idx = self.entries.insert(
+            Entry::Resident(Resident {
+                key,
+                value,
+                state,
+                referenced: Default::default(),
+            }),
+            *list_head,
+        );
+        list_head.get_or_insert(idx);
         self.map_insert(hash, idx);
         Ok(())
     }
@@ -966,11 +966,14 @@ impl<
         } else {
             let idx = self.entries.next_free();
             shared = Plh::new(hash, idx);
-            let idx_ = self.entries.insert(Entry::Placeholder(Placeholder {
-                key: key.to_owned(),
-                hot: ResidentState::Cold,
-                shared: shared.clone(),
-            }));
+            let idx_ = self.entries.insert(
+                Entry::Placeholder(Placeholder {
+                    key: key.to_owned(),
+                    hot: ResidentState::Cold,
+                    shared: shared.clone(),
+                }),
+                None,
+            );
             debug_assert_eq!(idx, idx_);
             self.map_insert(hash, idx);
         }


### PR DESCRIPTION
Reverts arthurprs/quick-cache#29

#29 causes problems if one uses get_mut/peek_mut (available on unsync cache) to replace a zero weight item with a non-zero one. I'm going to revert in order to avoid leaving `master` with a known bug.