### PR TITLE
sync cache reserve doesn't require a mutable reference & soft = true shouldn't change entry hotness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quick_cache"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 description = "Lightweight and high performance concurrent cache"
 repository = "https://github.com/arthurprs/quick-cache"

--- a/src/shard.rs
+++ b/src/shard.rs
@@ -656,7 +656,7 @@ impl<
             Entry::Resident(resident) => {
                 enter_state = resident.state;
                 referenced = *resident.referenced.get_mut()
-                    + (!matches!(strategy, InsertStrategy::Replace { soft: false })) as u16;
+                    + (!matches!(strategy, InsertStrategy::Replace { soft: true })) as u16;
             }
             _ if matches!(strategy, InsertStrategy::Replace { .. }) => {
                 return Err((key, value));

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -210,7 +210,7 @@ impl<
 
     /// Reserver additional space for `additional` entries.
     /// Note that this is counted in entries, and is not weighted.
-    pub fn reserve(&mut self, additional: usize) {
+    pub fn reserve(&self, additional: usize) {
         let additional_per_shard =
             additional.saturating_add(self.shards.len() - 1) / self.shards.len();
         for s in &*self.shards {


### PR DESCRIPTION
Closes #33 and #34