### PR TITLE
Document functions enabled by feature flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - run: cargo test --all-features --no-run
 
   shuttle-tests:
-    name: Tests
+    name: Shuttle Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -50,6 +50,20 @@ jobs:
           toolchain: stable
           override: true
       - run: cargo test --features shuttle shuttle
+
+  docs:
+    name: Build Docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - run: cargo doc --features stats --package quick_cache
+        env:
+          RUSTDOCFLAGS: --cfg docsrs
 
   fuzz-tests:
     name: Fuzz tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quick_cache"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Lightweight and high performance concurrent cache"
 repository = "https://github.com/arthurprs/quick-cache"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,7 @@ harness = false
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
+
+[package.metadata.docs.rs]
+features = ["stats"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "quick_cache"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "ahash",
  "equivalent",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,15 +51,13 @@
 //! a crate feature with the same name. If the `parking_lot` feature is disabled the crate defaults to the std lib
 //! implementation instead.
 #![allow(clippy::type_complexity)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(not(fuzzing))]
 mod linked_slab;
 #[cfg(fuzzing)]
 pub mod linked_slab;
-#[cfg(not(fuzzing))]
 mod options;
-#[cfg(fuzzing)]
-pub mod options;
 #[cfg(not(feature = "shuttle"))]
 mod rw_lock;
 mod shard;

--- a/src/unsync.rs
+++ b/src/unsync.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use std::hash::{BuildHasher, Hash};
 
+/// A non-concurrent cache.
 pub struct Cache<
     Key,
     Val,


### PR DESCRIPTION
As reported in #37, functions enabled via features like `stats` aren't discoverable in docs.rs

Closes #37