### PR TITLE
feat: add `retain` api for both  sync and unsync cache

### DIFF
--- a/src/shard.rs
+++ b/src/shard.rs
@@ -343,7 +343,8 @@ impl<
                 Some((entry, _idx)) => match entry {
                     Entry::Resident(r) => {
                         if f(&r.key, &r.value) {
-                            Some((idx, r.key))
+                            let hash = self.hash(&r.key);
+                            Some((idx, hash))
                         } else {
                             None
                         }
@@ -352,8 +353,7 @@ impl<
                 },
                 None => None,
             });
-        for (idx, key) in retained_tokens {
-            let hash = self.hash(&key);
+        for (idx, hash) in retained_tokens {
             self.remove_internal(hash, idx);
         }
     }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -287,6 +287,15 @@ impl<
         Ok(lcs)
     }
 
+    /// Retains only the items specified by the predicate.
+    /// In other words, remove all items for which `f(&key, &mut value)` returns `false`. The
+    /// elements are visited in unsorted (and unspecified) order.
+    pub fn retain<F>(&self, f: F)
+    where
+        F: FnMut(&Key, &mut Val) -> bool,
+    {
+    }
+
     /// Inserts an item in the cache with key `key`.
     pub fn insert(&self, key: Key, value: Val) {
         let lcs = self.insert_with_lifecycle(key, value);

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -295,7 +295,7 @@ impl<
         F: Fn(&Key, &Val) -> bool,
     {
         for s in self.shards.iter() {
-            s.write().retain(f);
+            s.write().retain(&f);
         }
     }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -288,12 +288,15 @@ impl<
     }
 
     /// Retains only the items specified by the predicate.
-    /// In other words, remove all items for which `f(&key, &mut value)` returns `false`. The
+    /// In other words, remove all items for which `f(&key, &value)` returns `false`. The
     /// elements are visited in unsorted (and unspecified) order.
     pub fn retain<F>(&self, f: F)
     where
-        F: FnMut(&Key, &mut Val) -> bool,
+        F: Fn(&Key, &Val) -> bool,
     {
+        for s in self.shards.iter() {
+            s.write().retain(f);
+        }
     }
 
     /// Inserts an item in the cache with key `key`.

--- a/src/unsync.rs
+++ b/src/unsync.rs
@@ -228,12 +228,13 @@ impl<Key: Eq + Hash, Val, We: Weighter<Key, Val>, B: BuildHasher, L: Lifecycle<K
     }
 
     /// Retains only the items specified by the predicate.
-    /// In other words, remove all items for which `f(&key, &mut value)` returns `false`. The
+    /// In other words, remove all items for which `f(&key, &value)` returns `false`. The
     /// elements are visited in unsorted (and unspecified) order.
     pub fn retain<F>(&mut self, f: F)
     where
-        F: FnMut(&Key, &mut Val) -> bool,
+        F: Fn(&Key, &Val) -> bool,
     {
+        self.shard.retain(f);
     }
 
     /// Gets or inserts an item in the cache with key `key`.

--- a/src/unsync.rs
+++ b/src/unsync.rs
@@ -227,6 +227,15 @@ impl<Key: Eq + Hash, Val, We: Weighter<Key, Val>, B: BuildHasher, L: Lifecycle<K
         Ok(lcs)
     }
 
+    /// Retains only the items specified by the predicate.
+    /// In other words, remove all items for which `f(&key, &mut value)` returns `false`. The
+    /// elements are visited in unsorted (and unspecified) order.
+    pub fn retain<F>(&mut self, f: F)
+    where
+        F: FnMut(&Key, &mut Val) -> bool,
+    {
+    }
+
     /// Gets or inserts an item in the cache with key `key`.
     /// Returns a reference to the inserted `value` if it was admitted to the cache.
     ///


### PR DESCRIPTION
Close #62 .

This PR adds a new API `retain`, it works similar to [`HashMap::retain`](https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.retain). It passes a predicate function `f` to detect whether an item inside the cache should be removed.

The predicate `f` has below signature:

```rust
Fn(&Key, &Val) -> bool
```

Note: this API won't change the hot/cold/hit information inside the cache.

TODO: Fix compiling issues, lint/clippy and add test cases.