### PR TITLE
feat: add retain api

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,26 +380,26 @@ mod tests {
             guard.insert(i);
             assert_eq!(cache.get_ref_or_guard(&i).ok().copied(), Some(i));
         }
-        let less_than = 3;
-        cache.retain(|&key, &val| val < less_than || key < less_than);
+        let small = 3;
+        cache.retain(|&key, &val| val > small && key > small);
         for i in ranges.clone() {
             let actual = cache.get(&i);
-            if i < less_than {
-                assert!(actual.is_none());
-            } else {
+            if i > small {
                 assert!(actual.is_some());
                 assert_eq!(*actual.unwrap(), i);
+            } else {
+                assert!(actual.is_none());
             }
         }
-        let greater_than = 7;
-        cache.retain(|&key, &val| val > greater_than || key > greater_than);
+        let big = 7;
+        cache.retain(|&key, &val| val < big && key < big);
         for i in ranges {
             let actual = cache.get(&i);
-            if i > greater_than || i < less_than {
-                assert!(actual.is_none());
-            } else {
+            if i > small && i < big {
                 assert!(actual.is_some());
                 assert_eq!(*actual.unwrap(), i);
+            } else {
+                assert!(actual.is_none());
             }
         }
     }
@@ -419,26 +419,26 @@ mod tests {
             };
             assert_eq!(v, i);
         }
-        let less_than = 4;
-        cache.retain(|&key, &val| val < less_than || key < less_than);
+        let small = 4;
+        cache.retain(|&key, &val| val > small && key > small);
         for i in ranges.clone() {
             let actual = cache.get(&i);
-            if i < less_than {
-                assert!(actual.is_none());
-            } else {
+            if i > small {
                 assert!(actual.is_some());
                 assert_eq!(actual.unwrap(), i);
+            } else {
+                assert!(actual.is_none());
             }
         }
-        let greater_than = 8;
-        cache.retain(|&key, &val| val > greater_than || key > greater_than);
+        let big = 8;
+        cache.retain(|&key, &val| val < big && key < big);
         for i in ranges {
             let actual = cache.get(&i);
-            if i < less_than || i > greater_than {
-                assert!(actual.is_none());
-            } else {
+            if i > small && i < big {
                 assert!(actual.is_some());
                 assert_eq!(actual.unwrap(), i);
+            } else {
+                assert!(actual.is_none());
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -372,7 +372,7 @@ mod tests {
     }
 
     #[test]
-    fn test_remove_unsync() {
+    fn test_retain_unsync() {
         let mut cache = unsync::Cache::<u64, u64>::new(100);
         let ranges = 0..10;
         for i in ranges.clone() {
@@ -405,7 +405,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_remove_sync() {
+    async fn test_retain_sync() {
         use crate::sync::*;
         let cache = Cache::<u64, u64>::new(100);
         let ranges = 0..10;

--- a/src/shard.rs
+++ b/src/shard.rs
@@ -332,6 +332,32 @@ impl<
         })
     }
 
+    pub fn retain<F>(&mut self, f: F)
+    where
+        F: Fn(&Key, &Val) -> bool,
+    {
+        let retained_tokens = self
+            .map
+            .iter()
+            .filter_map(|&idx| match self.entries.get(idx) {
+                Some((entry, _idx)) => match entry {
+                    Entry::Resident(r) => {
+                        if f(&r.key, &r.value) {
+                            let hash = self.hash(&r.key);
+                            Some((idx, hash))
+                        } else {
+                            None
+                        }
+                    }
+                    Entry::Placeholder(_) | Entry::Ghost(_) => None,
+                },
+                None => None,
+            });
+        for (idx, hash) in retained_tokens {
+            self.remove_internal(hash, idx);
+        }
+    }
+
     pub fn weight(&self) -> u64 {
         self.weight_hot + self.weight_cold
     }

--- a/src/shard.rs
+++ b/src/shard.rs
@@ -352,7 +352,8 @@ impl<
                     Entry::Placeholder(_) | Entry::Ghost(_) => None,
                 },
                 None => None,
-            });
+            })
+            .collect::<Vec<_>>();
         for (idx, hash) in retained_tokens {
             self.remove_internal(hash, idx);
         }

--- a/src/shard.rs
+++ b/src/shard.rs
@@ -342,7 +342,7 @@ impl<
             .filter_map(|&idx| match self.entries.get(idx) {
                 Some((entry, _idx)) => match entry {
                     Entry::Resident(r) => {
-                        if f(&r.key, &r.value) {
+                        if !f(&r.key, &r.value) {
                             let hash = self.hash(&r.key);
                             Some((idx, hash))
                         } else {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -287,6 +287,18 @@ impl<
         Ok(lcs)
     }
 
+    /// Retains only the items specified by the predicate.
+    /// In other words, remove all items for which `f(&key, &value)` returns `false`. The
+    /// elements are visited in unsorted (and unspecified) order.
+    pub fn retain<F>(&self, f: F)
+    where
+        F: Fn(&Key, &Val) -> bool,
+    {
+        for s in self.shards.iter() {
+            s.write().retain(&f);
+        }
+    }
+
     /// Inserts an item in the cache with key `key`.
     pub fn insert(&self, key: Key, value: Val) {
         let lcs = self.insert_with_lifecycle(key, value);

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -289,7 +289,7 @@ impl<
 
     /// Retains only the items specified by the predicate.
     /// In other words, remove all items for which `f(&key, &value)` returns `false`. The
-    /// elements are visited in unsorted (and unspecified) order.
+    /// elements are visited in arbitrary order.
     pub fn retain<F>(&self, f: F)
     where
         F: Fn(&Key, &Val) -> bool,

--- a/src/unsync.rs
+++ b/src/unsync.rs
@@ -229,7 +229,7 @@ impl<Key: Eq + Hash, Val, We: Weighter<Key, Val>, B: BuildHasher, L: Lifecycle<K
 
     /// Retains only the items specified by the predicate.
     /// In other words, remove all items for which `f(&key, &value)` returns `false`. The
-    /// elements are visited in unsorted (and unspecified) order.
+    /// elements are visited in arbitrary order.
     pub fn retain<F>(&mut self, f: F)
     where
         F: Fn(&Key, &Val) -> bool,

--- a/src/unsync.rs
+++ b/src/unsync.rs
@@ -227,6 +227,16 @@ impl<Key: Eq + Hash, Val, We: Weighter<Key, Val>, B: BuildHasher, L: Lifecycle<K
         Ok(lcs)
     }
 
+    /// Retains only the items specified by the predicate.
+    /// In other words, remove all items for which `f(&key, &value)` returns `false`. The
+    /// elements are visited in unsorted (and unspecified) order.
+    pub fn retain<F>(&mut self, f: F)
+    where
+        F: Fn(&Key, &Val) -> bool,
+    {
+        self.shard.retain(f);
+    }
+
     /// Gets or inserts an item in the cache with key `key`.
     /// Returns a reference to the inserted `value` if it was admitted to the cache.
     ///


### PR DESCRIPTION
Close #62 .

This PR adds a new API `retain`, it works similar to [`HashMap::retain`](https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.retain). It passes a predicate function `f` to detect whether an item inside the cache should be removed.

The predicate `f` has below signature:

```rust
Fn(&Key, &Val) -> bool
```

Note: 
1. This API won't change the hot/cold/hit information inside the cache.
2. The difference with `HashMap::retain` is the `f` signature, the `&val` is immutable.

- [x] TODO: Fix compiling issues, lint/clippy and add test cases.