### PR TITLE
Optimize placehold handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,21 @@ parking_lot = { optional = true, version = "0.12" }
 shuttle = { version = "0.8", optional = true }
 
 [dev-dependencies]
-criterion = "0.5"
+criterion = "0.7"
 rand = { version = "0.9", features = ["small_rng"] }
 rand_distr = "0.5"
 tokio = { version = "1", features = ["full"] }
 
 [[bench]]
 name = "benchmarks"
+harness = false
+
+[[bench]]
+name = "placeholder_bench"
+harness = false
+
+[[bench]]
+name = "placeholder_async_bench"
 harness = false
 
 [profile.shuttle]

--- a/benches/placeholder_async_bench.rs
+++ b/benches/placeholder_async_bench.rs
@@ -1,0 +1,115 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use quick_cache::sync::Cache;
+use std::sync::atomic::{self, AtomicUsize};
+use std::sync::Arc;
+use tokio::sync::Barrier;
+
+fn placeholder_async_contention_bench(c: &mut Criterion) {
+    let mut group = c.benchmark_group("placeholder_async_contention");
+
+    // Number of iterations each task will perform
+    const ITERATIONS: usize = 100;
+
+    // Test various contention scenarios
+    for num_tasks in [4, 8, 16, 32] {
+        group.bench_function(format!("{}", num_tasks), |b| {
+            let runtime = tokio::runtime::Runtime::new().unwrap();
+            b.iter(|| {
+                runtime.block_on(async {
+                    let cache = Arc::new(Cache::new(1000));
+                    let barrier = Arc::new(Barrier::new(num_tasks));
+                    let mut handles = vec![];
+
+                    // Spawn tasks that will perform multiple iterations
+                    for _ in 0..num_tasks {
+                        let cache = cache.clone();
+                        let barrier = barrier.clone();
+                        let handle = tokio::spawn(async move {
+                            barrier.wait().await;
+
+                            // Each task performs multiple cache operations
+                            for i in 0..ITERATIONS {
+                                match cache
+                                    .get_or_insert_async(&i, async { Ok::<_, ()>(i) })
+                                    .await
+                                {
+                                    Ok(_) => {}
+                                    Err(e) => panic!("Unexpected error: {:?}", e),
+                                }
+                            }
+                        });
+                        handles.push(handle);
+                    }
+
+                    // Wait for all tasks to complete
+                    for handle in handles {
+                        handle.await.unwrap();
+                    }
+                });
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn placeholder_async_handoff_bench(c: &mut Criterion) {
+    let mut group = c.benchmark_group("placeholder_async_handoff");
+
+    // Number of handoff iterations to perform
+    const ITERATIONS: usize = 100;
+
+    // Test handoff efficiency - measures how quickly guards are handed off between tasks
+    for num_waiters in [4, 8, 16, 32] {
+        group.bench_function(format!("{}", num_waiters), |b| {
+            let runtime = tokio::runtime::Runtime::new().unwrap();
+            b.iter(|| {
+                runtime.block_on(async {
+                    let cache = Arc::new(Cache::new(10000));
+                    let barrier = Arc::new(Barrier::new(num_waiters));
+                    let counters = Arc::new([const { AtomicUsize::new(0) }; ITERATIONS]);
+
+                    let mut handles = vec![];
+                    // Spawn waiter tasks that will queue up
+                    for _ in 0..num_waiters {
+                        let cache = cache.clone();
+                        let barrier = barrier.clone();
+                        let counters = counters.clone();
+                        let handle = tokio::spawn(async move {
+                            barrier.wait().await;
+                            for i in 0..ITERATIONS {
+                                loop {
+                                    match cache.get_value_or_guard_async(&i).await {
+                                        Ok(_v) => break,
+                                        Err(g) => {
+                                            if counters[i].fetch_add(1, atomic::Ordering::Relaxed)
+                                                == num_waiters - 1
+                                            {
+                                                g.insert(i).unwrap();
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        });
+                        handles.push(handle);
+                    }
+
+                    // Wait for all tasks
+                    for handle in handles {
+                        handle.await.unwrap();
+                    }
+                });
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    placeholder_async_contention_bench,
+    placeholder_async_handoff_bench
+);
+criterion_main!(benches);

--- a/benches/placeholder_bench.rs
+++ b/benches/placeholder_bench.rs
@@ -1,0 +1,95 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use quick_cache::sync::{Cache, GuardResult};
+use std::sync::atomic::{self, AtomicUsize};
+use std::sync::Barrier;
+use std::thread;
+
+fn placeholder_contention_bench(c: &mut Criterion) {
+    let mut group = c.benchmark_group("placeholder_contention");
+
+    // Number of iterations each thread will perform
+    const ITERATIONS: usize = 100;
+
+    // Test various contention scenarios
+    for num_threads in [4, 8, 16, 32] {
+        group.bench_function(format!("{}", num_threads), |b| {
+            b.iter(|| {
+                let cache = Cache::new(1000);
+                let barrier = Barrier::new(num_threads);
+
+                thread::scope(|s| {
+                    // Spawn threads that will perform multiple iterations
+                    for _ in 0..num_threads {
+                        s.spawn(|| {
+                            barrier.wait();
+
+                            // Each thread performs multiple cache operations
+                            for i in 0..ITERATIONS {
+                                match cache.get_value_or_guard(&i, None) {
+                                    GuardResult::Value(_) => {}
+                                    GuardResult::Guard(g) => {
+                                        g.insert(i).unwrap();
+                                    }
+                                    GuardResult::Timeout => panic!("Unexpected timeout"),
+                                };
+                            }
+                        });
+                    }
+                });
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn placeholder_handoff_bench(c: &mut Criterion) {
+    let mut group = c.benchmark_group("placeholder_handoff");
+
+    // Number of handoff iterations to perform
+    const ITERATIONS: usize = 100;
+
+    // Test handoff efficiency - measures how quickly guards are handed off between threads
+    for num_waiters in [4, 8, 16, 32] {
+        group.bench_function(format!("{}", num_waiters), |b| {
+            b.iter(|| {
+                let cache = Cache::new(10000);
+                let barrier = Barrier::new(num_waiters);
+                let counters = [const { AtomicUsize::new(0) }; ITERATIONS];
+
+                thread::scope(|s| {
+                    // Spawn waiter threads that will queue up
+                    for _ in 0..num_waiters {
+                        s.spawn(|| {
+                            barrier.wait();
+                            for i in 0..ITERATIONS {
+                                loop {
+                                    match cache.get_value_or_guard(&i, None) {
+                                        GuardResult::Value(_v) => break,
+                                        GuardResult::Guard(g) => {
+                                            if counters[i].fetch_add(1, atomic::Ordering::Relaxed)
+                                                == num_waiters - 1
+                                            {
+                                                g.insert(i).unwrap();
+                                            }
+                                        }
+                                        GuardResult::Timeout => panic!("Unexpected timeout"),
+                                    }
+                                }
+                            }
+                        });
+                    }
+                });
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    placeholder_contention_bench,
+    placeholder_handoff_bench
+);
+criterion_main!(benches);

--- a/src/shim.rs
+++ b/src/shim.rs
@@ -8,6 +8,11 @@ pub use std::{sync, thread};
 #[cfg(feature = "shuttle")]
 pub use shuttle::*;
 
+// TODO: OnceLock isn't current present in shuttle.
+// Using the std version like this only works in shuttle
+// because we're not relying on any OnceLock blocking behavior.
+pub use std::sync::OnceLock;
+
 #[cfg(feature = "shuttle")]
 pub mod rw_lock {
     use std::ops::{Deref, DerefMut};

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,6 +1,7 @@
 use std::{
     future::Future,
     hash::{BuildHasher, Hash},
+    hint::unreachable_unchecked,
     time::Duration,
 };
 
@@ -384,6 +385,8 @@ impl<
     /// is dropped or the value is inserted.
     ///
     /// A `None` `timeout` means waiting forever.
+    /// A `Some(<zero>)` timeout will return a Timeout error immediately if the value is not present
+    /// and a guard is alive elsewhere.
     pub fn get_value_or_guard<Q>(
         &self,
         key: &Q,
@@ -417,7 +420,7 @@ impl<
                 let _ = g.insert(v.clone());
                 Ok(v)
             }
-            GuardResult::Timeout => unreachable!(),
+            GuardResult::Timeout => unsafe { unreachable_unchecked() },
         }
     }
 

--- a/src/sync_placeholder.rs
+++ b/src/sync_placeholder.rs
@@ -1,7 +1,9 @@
 use std::{
     future::Future,
     hash::{BuildHasher, Hash},
-    task::Poll,
+    hint::unreachable_unchecked,
+    mem, pin,
+    task::{self, Poll},
     time::{Duration, Instant},
 };
 
@@ -9,12 +11,12 @@ use crate::{
     linked_slab::Token,
     shard::CacheShard,
     shim::{
-        rw_lock::{RwLock, RwLockReadGuard, RwLockWriteGuard},
+        rw_lock::{RwLock, RwLockWriteGuard},
         sync::{
-            atomic::{self, AtomicBool},
+            atomic::{AtomicBool, Ordering},
             Arc,
         },
-        thread,
+        thread, OnceLock,
     },
     Equivalent, Lifecycle, Weighter,
 };
@@ -26,6 +28,7 @@ impl<Val> crate::shard::SharedPlaceholder for SharedPlaceholder<Val> {
         Arc::new(Placeholder {
             hash,
             idx,
+            value: OnceLock::new(),
             state: RwLock::new(State {
                 waiters: Default::default(),
                 loading: LoadingState::Loading,
@@ -51,28 +54,27 @@ impl<Val> crate::shard::SharedPlaceholder for SharedPlaceholder<Val> {
 
 #[derive(Debug)]
 pub struct Placeholder<Val> {
-    pub hash: u64,
-    pub idx: Token,
-    pub state: RwLock<State<Val>>,
+    hash: u64,
+    idx: Token,
+    state: RwLock<State>,
+    value: OnceLock<Val>,
 }
 
 #[derive(Debug)]
-pub struct State<Val> {
+pub struct State {
     /// The waiters list
     /// Adding to the list requires holding the outer shard lock to avoid races between
     /// removing the orphan placeholder from the cache and adding a new waiter to it.
     waiters: Vec<Waiter>,
-    loading: LoadingState<Val>,
+    loading: LoadingState,
 }
 
 #[derive(Debug)]
-enum LoadingState<Val> {
+enum LoadingState {
     /// A guard was/will be created and the value might get filled
     Loading,
     /// A value was filled, no more waiters can be added
-    Inserted(Val),
-    /// The placeholder was abandoned w/o any waiters and was removed from the map
-    Terminated,
+    Inserted,
 }
 
 pub struct PlaceholderGuard<'a, Key, Val, We, B, L> {
@@ -83,43 +85,44 @@ pub struct PlaceholderGuard<'a, Key, Val, We, B, L> {
 }
 
 #[derive(Debug)]
-pub struct TaskWaiter {
-    notified: bool,
-    waker: std::task::Waker,
-}
-
-type SharedTaskWaiter = Arc<RwLock<TaskWaiter>>;
-
-#[derive(Debug)]
 enum Waiter {
-    Thread(thread::Thread, Arc<AtomicBool>),
-    Task(SharedTaskWaiter),
+    Thread {
+        notified: *const AtomicBool,
+        thread: thread::Thread,
+    },
+    Task {
+        notified: *const AtomicBool,
+        waker: task::Waker,
+    },
 }
+
+// SAFETY: The AtomicBool is on the waiting thread's stack or pinned future
+// and the thread/task will remove itself from waiters before returning
+unsafe impl Send for Waiter {}
+unsafe impl Sync for Waiter {}
 
 impl Waiter {
     #[inline]
     fn notify(self) {
         match self {
-            Waiter::Thread(t, n) => {
-                n.store(true, atomic::Ordering::Release);
-                t.unpark()
+            Waiter::Thread {
+                thread, notified, ..
+            } => {
+                // SAFETY: The AtomicBool is on the waiting thread's stack or pinned future
+                // and the thread/task will remove itself from waiters before returning
+                unsafe { notified.as_ref().unwrap().store(true, Ordering::Release) };
+                thread.unpark();
             }
-            Waiter::Task(t) => {
-                let mut t = t.write();
-                t.notified = true;
-                t.waker.wake_by_ref()
+            Waiter::Task { waker: t, notified } => {
+                unsafe { notified.as_ref().unwrap().store(true, Ordering::Release) };
+                t.wake();
             }
         }
     }
 
     #[inline]
-    fn is_task(&self, other: &SharedTaskWaiter) -> bool {
-        matches!(self, Waiter::Task(t) if Arc::ptr_eq(t, other))
-    }
-
-    #[inline]
-    fn is_thread(&self, other: thread::ThreadId) -> bool {
-        matches!(self, Waiter::Thread(t, _) if t.id() == other)
+    fn is_waiter(&self, other: *const AtomicBool) -> bool {
+        matches!(self, Waiter::Task { notified, .. } | Waiter::Thread { notified, .. } if std::ptr::eq(*notified, other))
     }
 }
 
@@ -148,43 +151,55 @@ impl<'a, Key, Val, We, B, L> PlaceholderGuard<'a, Key, Val, We, B, L> {
         }
     }
 
+    // Check the state of the placeholder, returning the value if it was loaded
+    // or a guard if the caller got the guard.
     #[inline]
-    fn join_internal(
+    fn handle_notification(
         lifecycle: &'a L,
-        // We take shard lock here even if unused, as manipulating the waiters list
-        // requires holding it to avoid races.
-        _shard_lock: Result<
-            RwLockWriteGuard<'a, CacheShard<Key, Val, We, B, L, SharedPlaceholder<Val>>>,
-            RwLockReadGuard<'a, CacheShard<Key, Val, We, B, L, SharedPlaceholder<Val>>>,
-        >,
         shard: &'a RwLock<CacheShard<Key, Val, We, B, L, SharedPlaceholder<Val>>>,
-        shared: &SharedPlaceholder<Val>,
-        notified: bool,
-        waiter_fn: impl FnOnce() -> Waiter,
-    ) -> Option<Result<Val, PlaceholderGuard<'a, Key, Val, We, B, L>>>
+        shared: SharedPlaceholder<Val>,
+    ) -> Result<Val, PlaceholderGuard<'a, Key, Val, We, B, L>>
     where
         Val: Clone,
     {
-        if notified {
-            let state = shared.state.read();
-            match &state.loading {
-                LoadingState::Loading => {
-                    drop(state);
-                    Some(Err(Self::start_loading(lifecycle, shard, shared.clone())))
-                }
-                LoadingState::Inserted(value) => Some(Ok(value.clone())),
-                LoadingState::Terminated => unreachable!(),
-            }
+        // Check if the value was loaded, and if it wasn't it means we got the
+        // guard and need to start loading the value.
+        if let Some(v) = shared.value.get() {
+            Ok(v.clone())
         } else {
-            let mut state = shared.state.write();
-            match &state.loading {
-                LoadingState::Loading => {
-                    state.waiters.push(waiter_fn());
-                    None
+            Err(PlaceholderGuard::start_loading(lifecycle, shard, shared))
+        }
+    }
+
+    // Join the waiters list or return the value if it was already loaded
+    #[inline]
+    fn join_waiters(
+        // we require the shard lock to be held to add a new waiter
+        _locked_shard: RwLockWriteGuard<'a, CacheShard<Key, Val, We, B, L, SharedPlaceholder<Val>>>,
+        shared: &SharedPlaceholder<Val>,
+        // a function that returns a waiter if it should be added
+        waiter_new: impl FnOnce() -> Option<Waiter>,
+    ) -> Option<Val>
+    where
+        Val: Clone,
+    {
+        let mut state = shared.state.write();
+        // _locked_shard could be released here, it would be sufficient to synchronize with the holder
+        // of the guard trying to remove the placeholder from the cache. But if this placeholder is hot,
+        // anyone waiting on the shard will immediately hit the state lock. Since the cache is sharded
+        // we consider the latter more likely. So we keep the shard lock until we are done with the state.
+        match state.loading {
+            LoadingState::Loading => {
+                if let Some(waiter) = waiter_new() {
+                    state.waiters.push(waiter);
                 }
-                LoadingState::Inserted(value) => Some(Ok(value.clone())),
-                LoadingState::Terminated => unreachable!(),
+                None
             }
+            LoadingState::Inserted => unsafe {
+                // SAFETY: The value is guaranteed to be set at this point
+                drop(state); // Allow cloning outside the lock
+                Some(shared.value.get().unwrap_unchecked().clone())
+            },
         }
     }
 }
@@ -203,7 +218,7 @@ impl<
         shard: &'a RwLock<CacheShard<Key, Val, We, B, L, SharedPlaceholder<Val>>>,
         hash: u64,
         key: &Q,
-        timeout: Option<Duration>,
+        mut timeout: Option<Duration>,
     ) -> GuardResult<'a, Key, Val, We, B, L>
     where
         Q: Hash + Equivalent<Key> + ToOwned<Owned = Key> + ?Sized,
@@ -216,58 +231,85 @@ impl<
             }
             Err((shared, false)) => shared,
         };
-        let mut notification: Option<Arc<AtomicBool>> = None;
-        let mut notified = false;
-        let mut shard_guard = Ok(shard_guard);
-        loop {
-            if let Some(result) =
-                Self::join_internal(lifecycle, shard_guard, shard, &shared, notified, || {
-                    Waiter::Thread(
-                        thread::current(),
-                        notification.get_or_insert_with(Default::default).clone(),
-                    )
+
+        // Create notified flag on stack - this will live for the entire duration of join
+        let notified = pin::pin!(AtomicBool::new(false));
+        // Set if the thread was added to the waiters list
+        let mut parked_thread = None;
+        let maybe_val = Self::join_waiters(shard_guard, &shared, || {
+            if timeout.is_some_and(|t| t.is_zero()) {
+                None
+            } else {
+                let thread = thread::current();
+                let id = thread.id();
+                parked_thread = Some(id);
+                Some(Waiter::Thread {
+                    thread,
+                    notified: &*notified as *const AtomicBool,
                 })
-            {
-                return match result {
+            }
+        });
+        if let Some(v) = maybe_val {
+            return GuardResult::Value(v);
+        }
+
+        // Track the start time of the timeout, set lazily
+        let mut timeout_start = None;
+        loop {
+            if let Some(remaining) = timeout {
+                if remaining.is_zero() {
+                    return Self::join_timeout(lifecycle, shard, shared, parked_thread, &notified);
+                }
+                let start = *timeout_start.get_or_insert_with(Instant::now);
+                #[cfg(not(fuzzing))]
+                thread::park_timeout(remaining);
+                timeout = Some(remaining.saturating_sub(start.elapsed()));
+            } else {
+                thread::park();
+            }
+            if notified.load(Ordering::Acquire) {
+                return match Self::handle_notification(lifecycle, shard, shared) {
                     Ok(v) => GuardResult::Value(v),
                     Err(g) => GuardResult::Guard(g),
                 };
             }
-            let notification = notification.as_ref().unwrap();
-            if let Some(timeout) = timeout {
-                let start = Instant::now();
-                loop {
-                    #[cfg(not(fuzzing))]
-                    thread::park_timeout(Instant::now().saturating_duration_since(start));
-                    if notification.load(atomic::Ordering::Acquire) {
-                        break;
-                    }
-                    // for shuttle assume no spurious unparks as the timeout isn't respected anyway
-                    if !cfg!(feature = "shuttle") && start.elapsed() < timeout {
-                        // spurious unpark
-                        continue;
-                    }
-                    // Lock state and re-check
-                    let mut state = shared.state.write();
-                    if notification.load(atomic::Ordering::Acquire) {
-                        break;
-                    }
-                    // We really timed out... remove from waiters list
-                    let tid = thread::current().id();
-                    let waiter_idx = state.waiters.iter().position(|w| w.is_thread(tid));
-                    state.waiters.swap_remove(waiter_idx.unwrap());
-                    return GuardResult::Timeout;
-                }
-            } else {
-                loop {
-                    thread::park();
-                    if notification.load(atomic::Ordering::Acquire) {
-                        break;
-                    }
-                }
+        }
+    }
+
+    #[cold]
+    fn join_timeout(
+        lifecycle: &'a L,
+        shard: &'a RwLock<CacheShard<Key, Val, We, B, L, Arc<Placeholder<Val>>>>,
+        shared: Arc<Placeholder<Val>>,
+        // when timeout is zero, the thread may have not been added to the waiters list
+        parked_thread: Option<thread::ThreadId>,
+        notified: &AtomicBool,
+    ) -> GuardResult<'a, Key, Val, We, B, L> {
+        let mut state = shared.state.write();
+        match state.loading {
+            LoadingState::Loading if notified.load(Ordering::Acquire) => {
+                drop(state); // Drop state guard to avoid a deadlock with start_loading
+                GuardResult::Guard(PlaceholderGuard::start_loading(lifecycle, shard, shared))
             }
-            notified = true;
-            shard_guard = Err(shard.read());
+            LoadingState::Loading => {
+                if parked_thread.is_some() {
+                    // Remove ourselves from the waiters list
+                    let waiter_idx = state
+                        .waiters
+                        .iter()
+                        .position(|w| w.is_waiter(notified as _));
+                    if let Some(idx) = waiter_idx {
+                        state.waiters.swap_remove(idx);
+                    } else {
+                        unsafe { unreachable_unchecked() };
+                    }
+                }
+                GuardResult::Timeout
+            }
+            LoadingState::Inserted => unsafe {
+                // SAFETY: The value is guaranteed to be set at this point
+                GuardResult::Value(shared.value.get().unwrap_unchecked().clone())
+            },
         }
     }
 }
@@ -298,10 +340,14 @@ impl<
     /// A placeholder can be removed as a result of a `remove` call
     /// or a non-placeholder `insert` with the same key.
     pub fn insert_with_lifecycle(mut self, value: Val) -> Result<L::RequestState, Val> {
+        unsafe { self.shared.value.set(value.clone()).unwrap_unchecked() };
         let referenced;
         {
+            // Whoever is already waiting will get notified and hit the fast-path
+            // as they will see the value set. Anyone that races trying to add themselves
+            // to the waiters list will wait on the state lock.
             let mut state = self.shared.state.write();
-            state.loading = LoadingState::Inserted(value.clone());
+            state.loading = LoadingState::Inserted;
             referenced = !state.waiters.is_empty();
             for w in state.waiters.drain(..) {
                 w.notify();
@@ -325,20 +371,35 @@ impl<
 impl<Key, Val, We, B, L> PlaceholderGuard<'_, Key, Val, We, B, L> {
     #[cold]
     fn drop_uninserted_slow(&mut self) {
-        // Make sure to acquire the shard lock to prevent races with other threads
-        let mut shard = self.shard.write();
-        let mut state = self.shared.state.write();
-        if let Some(w) = state.waiters.pop() {
+        // Fast path: check if there are other waiters without the shard lock
+        // This may or may not be common, but the assumption is that the shard lock is hot
+        // and should be avoided if possible.
+        {
+            let mut state = self.shared.state.write();
             debug_assert!(matches!(state.loading, LoadingState::Loading));
-            w.notify();
+            if let Some(waiter) = state.waiters.pop() {
+                waiter.notify();
+                return;
+            }
+        }
+
+        // Slow path: acquire shard lock and re-check
+        // By acquiring the shard lock we synchronize with any other threads that might be
+        // trying to add themselves to the waiters list.
+        let mut shard_guard = self.shard.write();
+        let mut state = self.shared.state.write();
+        debug_assert!(matches!(state.loading, LoadingState::Loading));
+        if let Some(waiter) = state.waiters.pop() {
+            drop(shard_guard);
+            waiter.notify();
         } else {
-            state.loading = LoadingState::Terminated;
-            shard.remove_placeholder(&self.shared);
+            shard_guard.remove_placeholder(&self.shared);
         }
     }
 }
 
 impl<Key, Val, We, B, L> Drop for PlaceholderGuard<'_, Key, Val, We, B, L> {
+    #[inline]
     fn drop(&mut self) {
         if !self.inserted {
             self.drop_uninserted_slow();
@@ -352,18 +413,21 @@ impl<Key, Val, We, B, L> std::fmt::Debug for PlaceholderGuard<'_, Key, Val, We, 
 }
 
 /// Future that results in an Ok(Value) or Err(Guard)
-pub enum JoinFuture<'a, 'b, Q: ?Sized, Key, Val, We, B, L> {
+pub struct JoinFuture<'a, 'b, Q: ?Sized, Key, Val, We, B, L> {
+    lifecycle: &'a L,
+    shard: &'a RwLock<CacheShard<Key, Val, We, B, L, SharedPlaceholder<Val>>>,
+    state: JoinFutureState<'b, Q, Val>,
+    notified: AtomicBool,
+}
+
+enum JoinFutureState<'b, Q: ?Sized, Val> {
     Created {
-        lifecycle: &'a L,
-        shard: &'a RwLock<CacheShard<Key, Val, We, B, L, SharedPlaceholder<Val>>>,
         hash: u64,
         key: &'b Q,
     },
     Pending {
-        lifecycle: &'a L,
-        shard: &'a RwLock<CacheShard<Key, Val, We, B, L, SharedPlaceholder<Val>>>,
         shared: SharedPlaceholder<Val>,
-        waiter: Option<SharedTaskWaiter>,
+        waker: task::Waker,
     },
     Done,
 }
@@ -375,37 +439,43 @@ impl<'a, 'b, Q: ?Sized, Key, Val, We, B, L> JoinFuture<'a, 'b, Q, Key, Val, We, 
         hash: u64,
         key: &'b Q,
     ) -> JoinFuture<'a, 'b, Q, Key, Val, We, B, L> {
-        JoinFuture::Created {
+        Self {
             lifecycle,
             shard,
-            hash,
-            key,
+            state: JoinFutureState::Created { hash, key },
+            notified: Default::default(),
         }
     }
 
     #[cold]
     fn drop_pending_waiter(&mut self) {
-        let Self::Pending {
-            lifecycle,
-            shard,
-            shared,
-            waiter: Some(waiter),
-        } = self
+        let JoinFutureState::Pending { shared, .. } =
+            mem::replace(&mut self.state, JoinFutureState::Done)
         else {
-            unreachable!()
+            unsafe { unreachable_unchecked() }
         };
         let mut state = shared.state.write();
-        let notified = waiter.read().notified; // Drop waiter guard to avoid a deadlock with start_loading
-        if notified {
-            if matches!(state.loading, LoadingState::Loading) {
+        match state.loading {
+            LoadingState::Loading if self.notified.load(Ordering::Acquire) => {
                 // The write guard was abandoned elsewhere, this future was notified but didn't get polled.
                 // So we get and drop the guard here to handle the side effects.
                 drop(state); // Drop state guard to avoid a deadlock with start_loading
-                let _ = PlaceholderGuard::start_loading(*lifecycle, *shard, shared.clone());
+                let _ = PlaceholderGuard::start_loading(self.lifecycle, self.shard, shared);
             }
-        } else {
-            let waiter_idx = state.waiters.iter().position(|w| w.is_task(waiter));
-            state.waiters.swap_remove(waiter_idx.unwrap());
+            LoadingState::Loading => {
+                // Remove ourselves from the waiters list
+                let waiter_idx = state
+                    .waiters
+                    .iter()
+                    .position(|w| w.is_waiter(&self.notified as _));
+                if let Some(idx) = waiter_idx {
+                    state.waiters.swap_remove(idx);
+                } else {
+                    // We didn't find ourselves in the waiters list!?
+                    unsafe { unreachable_unchecked() }
+                }
+            }
+            LoadingState::Inserted => (), // We were notified but didn't get polled - nothing to do
         }
     }
 }
@@ -413,13 +483,7 @@ impl<'a, 'b, Q: ?Sized, Key, Val, We, B, L> JoinFuture<'a, 'b, Q, Key, Val, We, 
 impl<Q: ?Sized, Key, Val, We, B, L> Drop for JoinFuture<'_, '_, Q, Key, Val, We, B, L> {
     #[inline]
     fn drop(&mut self) {
-        if matches!(
-            self,
-            Self::Pending {
-                waiter: Some(_),
-                ..
-            }
-        ) {
+        if matches!(self.state, JoinFutureState::Pending { .. }) {
             self.drop_pending_waiter();
         }
     }
@@ -437,98 +501,80 @@ impl<
 {
     type Output = Result<Val, PlaceholderGuard<'a, Key, Val, We, B, L>>;
 
-    fn poll(
-        mut self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> Poll<Self::Output> {
-        let shard_guard = match &*self {
-            JoinFuture::Created {
-                lifecycle,
-                shard,
-                hash,
-                key,
-            } => {
+    fn poll(mut self: pin::Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+        let this = &mut *self;
+        let lifecycle = this.lifecycle;
+        let shard = this.shard;
+        match &mut this.state {
+            JoinFutureState::Created { hash, key } => {
+                debug_assert!(!this.notified.load(Ordering::Acquire));
                 let mut shard_guard = shard.write();
                 match shard_guard.upsert_placeholder(*hash, *key) {
                     Ok((_, v)) => {
-                        *self = Self::Done;
-                        return Poll::Ready(Ok(v.clone()));
+                        this.state = JoinFutureState::Done;
+                        Poll::Ready(Ok(v.clone()))
                     }
                     Err((shared, true)) => {
-                        let guard = PlaceholderGuard::start_loading(*lifecycle, *shard, shared);
-                        *self = Self::Done;
-                        return Poll::Ready(Err(guard));
+                        let guard = PlaceholderGuard::start_loading(lifecycle, shard, shared);
+                        this.state = JoinFutureState::Done;
+                        Poll::Ready(Err(guard))
                     }
                     Err((shared, false)) => {
-                        *self = Self::Pending {
-                            lifecycle,
-                            shard,
-                            shared,
-                            waiter: None,
-                        };
-                        Ok(shard_guard)
+                        let mut waker = None;
+                        let maybe_val =
+                            PlaceholderGuard::join_waiters(shard_guard, &shared, || {
+                                let waker_ = cx.waker().clone();
+                                waker = Some(waker_.clone());
+                                Some(Waiter::Task {
+                                    waker: waker_,
+                                    notified: &this.notified as *const AtomicBool,
+                                })
+                            });
+                        if let Some(v) = maybe_val {
+                            debug_assert!(waker.is_none());
+                            debug_assert!(!this.notified.load(Ordering::Acquire));
+                            this.state = JoinFutureState::Done;
+                            Poll::Ready(Ok(v))
+                        } else {
+                            let waker = waker.unwrap();
+                            this.state = JoinFutureState::Pending { shared, waker };
+                            Poll::Pending
+                        }
                     }
                 }
             }
-            JoinFuture::Pending {
-                shard,
-                waiter: Some(waiter),
-                ..
-            } => {
-                let mut waiter = waiter.write();
-                if waiter.notified {
-                    waiter.notified = false;
-                } else {
-                    waiter.waker.clone_from(cx.waker());
-                    return Poll::Pending;
+            JoinFutureState::Pending { .. } if this.notified.load(Ordering::Acquire) => {
+                let JoinFutureState::Pending { shared, .. } =
+                    mem::replace(&mut this.state, JoinFutureState::Done)
+                else {
+                    unsafe { unreachable_unchecked() }
+                };
+                Poll::Ready(PlaceholderGuard::handle_notification(
+                    lifecycle, shard, shared,
+                ))
+            }
+            JoinFutureState::Pending { waker, shared } => {
+                // Update waker in case it changed
+                let new_waker = cx.waker();
+                if !waker.will_wake(new_waker) {
+                    let mut state = shared.state.write();
+                    if let Some(w) = state
+                        .waiters
+                        .iter_mut()
+                        .find(|w| w.is_waiter(&this.notified as _))
+                    {
+                        *waker = new_waker.clone();
+                        *w = Waiter::Task {
+                            waker: new_waker.clone(),
+                            notified: &this.notified as *const AtomicBool,
+                        };
+                    } else {
+                        unsafe { unreachable_unchecked() };
+                    }
                 }
-                // drop waiter first to avoid deadlock due to lock order
-                drop(waiter);
-                Err(shard.read())
-            }
-            JoinFuture::Pending { .. } => unreachable!(),
-            JoinFuture::Done => panic!("Polled after ready"),
-        };
-
-        let Self::Pending {
-            lifecycle,
-            shard,
-            shared,
-            waiter,
-        } = &mut *self
-        else {
-            unreachable!()
-        };
-        // If we reach here and waiter is some, it means we got a notification.
-        let notified = waiter.is_some();
-        let waiter_fn = || {
-            let task_waiter = waiter
-                .get_or_insert_with(|| {
-                    Arc::new(RwLock::new(TaskWaiter {
-                        notified: false,
-                        waker: cx.waker().clone(),
-                    }))
-                })
-                .clone();
-            Waiter::Task(task_waiter)
-        };
-        match PlaceholderGuard::join_internal(
-            *lifecycle,
-            shard_guard,
-            *shard,
-            shared,
-            notified,
-            waiter_fn,
-        ) {
-            Some(result) => {
-                *waiter = None;
-                *self = Self::Done;
-                Poll::Ready(result)
-            }
-            None => {
-                debug_assert!(waiter.is_some());
                 Poll::Pending
             }
+            JoinFutureState::Done => panic!("Polled after ready"),
         }
     }
 }


### PR DESCRIPTION
This PR optimizes the placeholder handling mechanism in the cache implementation by separating value storage from state management using `OnceLock` and by using a pinned AtomicBool for notifications.

These modifications reduce lock contention and baseline waiting costs (e.g., the Arc allocation for notification is eliminated).