### PR TITLE
wip: add get_validate_value_or_guard_async

### DIFF
--- a/src/shard.rs
+++ b/src/shard.rs
@@ -1050,10 +1050,16 @@ impl<
         Ok(())
     }
 
+    /// Upserts a placeholder, optionally validating existing resident values
+    ///
+    /// Returns:
+    /// - `Ok((token, value))` if a valid resident was found
+    /// - `Err((placeholder, is_new))` where `is_new` indicates if this is a newly created placeholder
     pub fn upsert_placeholder<Q>(
         &mut self,
         hash: u64,
         key: &Q,
+        validator: &mut impl FnMut(&Val) -> bool,
     ) -> Result<(Token, &Val), (Plh, bool)>
     where
         Q: Hash + Equivalent<Key> + ToOwned<Owned = Key> + ?Sized,
@@ -1063,6 +1069,40 @@ impl<
             let (entry, _) = self.entries.get_mut(idx).unwrap();
             match entry {
                 Entry::Resident(resident) => {
+                    if !validator(&resident.value) {
+                        let old_state = resident.state;
+                        let old_key = &resident.key;
+                        let old_value = &resident.value;
+                        let weight = self.weighter.weight(old_key, old_value);
+
+                        let shared = Plh::new(hash, idx);
+                        *entry = Entry::Placeholder(Placeholder {
+                            key: key.to_owned(),
+                            hot: old_state,
+                            shared: shared.clone(),
+                        });
+
+                        match old_state {
+                            ResidentState::Hot => {
+                                self.num_hot -= 1;
+                                self.weight_hot -= weight;
+                                if weight != 0 {
+                                    self.hot_head = self.entries.unlink(idx);
+                                }
+                            }
+                            ResidentState::Cold => {
+                                self.num_cold -= 1;
+                                self.weight_cold -= weight;
+                                if weight != 0 {
+                                    self.cold_head = self.entries.unlink(idx);
+                                }
+                            }
+                        }
+
+                        record_miss_mut!(self);
+                        return Err((shared, false)); // false = replaced existing
+                    }
+
                     if *resident.referenced.get_mut() < MAX_F {
                         *resident.referenced.get_mut() += 1;
                     }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -438,11 +438,40 @@ impl<
     where
         Q: Hash + Equivalent<Key> + ToOwned<Owned = Key> + ?Sized,
     {
+        self.get_validate_value_or_guard_async(key, |_| true).await
+    }
+
+    /// Gets an item from the cache with key `key`, applying `validation` to determine whether
+    /// the value is 'live'.
+    ///
+    /// If the corresponding value isn't present in the cache or fails validation, this functions
+    /// returns a guard that can be used to insert the value once it's computed.
+    /// While the returned guard is alive, other calls with the same key using the
+    /// `get_value_guard` or `get_or_insert` family of functions will wait until the guard
+    /// is dropped or the value is inserted.
+    pub async fn get_validate_value_or_guard_async<'a, Q>(
+        &'a self,
+        key: &Q,
+        mut validation: impl FnMut(&Val) -> bool + Unpin,
+    ) -> Result<Val, PlaceholderGuard<'a, Key, Val, We, B, L>>
+    where
+        Q: Hash + Equivalent<Key> + ToOwned<Owned = Key> + ?Sized,
+    {
         let (shard, hash) = self.shard_for(key).unwrap();
-        if let Some(v) = shard.read().get(hash, key) {
-            return Ok(v.clone());
+
+        // Try fast path with read lock first
+        {
+            let reader = shard.read();
+            if let Some(v) = reader.get(hash, key) {
+                if validation(v) {
+                    return Ok(v.clone());
+                }
+                // Validation failed, fall through to JoinFuture
+            }
+            // No entry found or validation failed, let JoinFuture handle everything
         }
-        JoinFuture::new(&self.lifecycle, shard, hash, key).await
+
+        JoinFuture::new(&self.lifecycle, shard, hash, key, validation).await
     }
 
     /// Gets or inserts an item in the cache with key `key`.

--- a/src/unsync.rs
+++ b/src/unsync.rs
@@ -249,7 +249,10 @@ impl<Key: Eq + Hash, Val, We: Weighter<Key, Val>, B: BuildHasher, L: Lifecycle<K
     where
         Q: Hash + Equivalent<Key> + ToOwned<Owned = Key> + ?Sized,
     {
-        let idx = match self.shard.upsert_placeholder(self.shard.hash(key), key) {
+        let idx = match self
+            .shard
+            .upsert_placeholder(self.shard.hash(key), key, &mut |_| true)
+        {
             Ok((idx, _)) => idx,
             Err((plh, _)) => {
                 let v = with()?;
@@ -275,7 +278,10 @@ impl<Key: Eq + Hash, Val, We: Weighter<Key, Val>, B: BuildHasher, L: Lifecycle<K
     where
         Q: Hash + Equivalent<Key> + ToOwned<Owned = Key> + ?Sized,
     {
-        let idx = match self.shard.upsert_placeholder(self.shard.hash(key), key) {
+        let idx = match self
+            .shard
+            .upsert_placeholder(self.shard.hash(key), key, &mut |_| true)
+        {
             Ok((idx, _)) => idx,
             Err((plh, _)) => {
                 let v = with()?;
@@ -297,7 +303,10 @@ impl<Key: Eq + Hash, Val, We: Weighter<Key, Val>, B: BuildHasher, L: Lifecycle<K
         Q: Hash + Equivalent<Key> + ToOwned<Owned = Key> + ?Sized,
     {
         // TODO: this could be using a simpler entry API
-        match self.shard.upsert_placeholder(self.shard.hash(key), key) {
+        match self
+            .shard
+            .upsert_placeholder(self.shard.hash(key), key, &mut |_| true)
+        {
             Ok((_, v)) => unsafe {
                 // Rustc gets insanely confused about returning from mut borrows
                 // Safety: v has the same lifetime as self
@@ -323,7 +332,10 @@ impl<Key: Eq + Hash, Val, We: Weighter<Key, Val>, B: BuildHasher, L: Lifecycle<K
         Q: Hash + Equivalent<Key> + ToOwned<Owned = Key> + ?Sized,
     {
         // TODO: this could be using a simpler entry API
-        match self.shard.upsert_placeholder(self.shard.hash(key), key) {
+        match self
+            .shard
+            .upsert_placeholder(self.shard.hash(key), key, &mut |_| true)
+        {
             Ok((idx, _)) => Ok(self.shard.peek_token_mut(idx).map(RefMut)),
             Err((placeholder, _)) => Err(Guard {
                 cache: self,


### PR DESCRIPTION
This PR implements a solution to #73, introducing a `get_validate_or_guard_async` method which allows passing a validation function to determine whether we should consider the currently inserted value as 'live'. If the value fails validation it will be replaced with a `Placeholder` and the guard returned. 

todo:
- [ ] tests
- [ ] unsync versions
- [ ] non-async apis
- [ ] bench to confirm no perf regression (shouldn't be the case).

 
