### PR TITLE
Added Cache::remove_if

### DIFF
--- a/src/shard.rs
+++ b/src/shard.rs
@@ -604,6 +604,19 @@ impl<
         self.remove_internal(hash, idx)
     }
 
+    pub fn remove_if<Q, F>(&mut self, hash: u64, key: &Q, f: F) -> Option<(Key, Val)>
+    where
+        Q: Hash + Equivalent<Key> + ?Sized,
+        F: FnOnce(&Val) -> bool,
+    {
+        let (idx, resident) = self.search_resident(hash, key)?;
+        if f(&resident.value) {
+            self.remove_internal(hash, idx)
+        } else {
+            None
+        }
+    }
+
     pub fn remove_token(&mut self, token: Token) -> Option<(Key, Val)> {
         let Some((Entry::Resident(resident), _)) = self.entries.get(token) else {
             return None;


### PR DESCRIPTION
Thanks for this crate, it's awesome! One thing that was missing for me is ability to remove the entry only if its value matches what I expect. I've added `Cache::remove_if` which makes it possible to achieve that.

~I've added it only for the `sync` version of the `Cache`, as with `unsync`  version you can just do `peek` + `remove`, but let me know if I should add it to `unsync` too for consistency.~