### PR TITLE
Add shard_index method

### DIFF
--- a/src/sync.rs
+++ b/src/sync.rs
@@ -209,16 +209,34 @@ impl<
     }
 
     #[inline]
-    pub fn shard_index<Q: Hash>(&self, key: &Q) -> usize {
-        // When choosing the shard, rotate the hash bits usize::BITS / 2 so that we
+    fn compute_shard_index(&self, hash: u64) -> u64 {
         // give preference to the bits in the middle of the hash.
+        // When choosing the shard, rotate the hash bits usize::BITS / 2 so that we
         // Internally hashbrown uses the lower bits for start of probing + the 7 highest,
         // so by picking something else we improve the real entropy available to each hashbrown shard.
-        (self
-            .hash_builder
-            .hash_one(key)
-            .rotate_right(usize::BITS / 2)
-            & self.shards_mask) as usize
+        hash.rotate_right(usize::BITS / 2) & self.shards_mask
+    }
+
+    /// Returns the shard index for the given key.
+    ///
+    /// The returned index is guaranteed to be in `[0, num_shards())`.
+    ///
+    /// # Use cases
+    ///
+    /// - **Batching**: group keys by shard index before acquiring shard locks, so
+    ///   each lock is taken only once per batch instead of once per key.
+    ///
+    /// # Notes
+    ///
+    /// The mapping from key to shard index depends on the [`BuildHasher`] supplied
+    /// at construction time. If two `Cache` instances are built with different
+    /// hashers, the same key may map to different shard indices.
+    ///
+    /// [`BuildHasher`]: std::hash::BuildHasher
+    #[inline]
+    pub fn shard_index<Q: Hash + ?Sized>(&self, key: &Q) -> usize {
+        let hash = self.hash_builder.hash_one(key);
+        self.compute_shard_index(hash) as usize
     }
 
     #[inline]
@@ -233,11 +251,7 @@ impl<
         Q: Hash + Equivalent<Key> + ?Sized,
     {
         let hash = self.hash_builder.hash_one(key);
-        // When choosing the shard, rotate the hash bits usize::BITS / 2 so that we
-        // give preference to the bits in the middle of the hash.
-        // Internally hashbrown uses the lower bits for start of probing + the 7 highest,
-        // so by picking something else we improve the real entropy available to each hashbrown shard.
-        let shard_idx = (hash.rotate_right(usize::BITS / 2) & self.shards_mask) as usize;
+        let shard_idx = self.compute_shard_index(hash) as usize;
         self.shards.get(shard_idx).map(|s| (s, hash))
     }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -210,10 +210,10 @@ impl<
 
     #[inline]
     fn compute_shard_index(&self, hash: u64) -> u64 {
-        // give preference to the bits in the middle of the hash.
-        // When choosing the shard, rotate the hash bits usize::BITS / 2 so that we
-        // Internally hashbrown uses the lower bits for start of probing + the 7 highest,
-        // so by picking something else we improve the real entropy available to each hashbrown shard.
+        // Give preference to the bits in the middle of the hash. When choosing the
+        // shard, rotate the hash by usize::BITS / 2 so we avoid the lower bits and
+        // the highest 7 bits that hashbrown uses internally for probing, improving
+        // the real entropy available to each hashbrown shard.
         hash.rotate_right(usize::BITS / 2) & self.shards_mask
     }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -234,7 +234,7 @@ impl<
     ///
     /// [`BuildHasher`]: std::hash::BuildHasher
     #[inline]
-    pub fn shard_index<Q: Hash + ?Sized>(&self, key: &Q) -> usize {
+    pub fn shard_index<Q: Hash + Equivalent<Key> + ?Sized>(&self, key: &Q) -> usize {
         let hash = self.hash_builder.hash_one(key);
         self.compute_shard_index(hash) as usize
     }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -209,10 +209,7 @@ impl<
     }
 
     #[inline]
-    pub fn shard_index<Q>(&self, key: &Q) -> usize
-    where
-        Q: Hash + Equivalent<Key> + ?Sized,
-    {
+    pub fn shard_index<Q: Hash>(&self, key: &Q) -> usize {
         // When choosing the shard, rotate the hash bits usize::BITS / 2 so that we
         // give preference to the bits in the middle of the hash.
         // Internally hashbrown uses the lower bits for start of probing + the 7 highest,

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -209,6 +209,22 @@ impl<
     }
 
     #[inline]
+    pub fn shard_index<Q>(&self, key: &Q) -> usize
+    where
+        Q: Hash + Equivalent<Key> + ?Sized,
+    {
+        // When choosing the shard, rotate the hash bits usize::BITS / 2 so that we
+        // give preference to the bits in the middle of the hash.
+        // Internally hashbrown uses the lower bits for start of probing + the 7 highest,
+        // so by picking something else we improve the real entropy available to each hashbrown shard.
+        (self
+            .hash_builder
+            .hash_one(key)
+            .rotate_right(usize::BITS / 2)
+            & self.shards_mask) as usize
+    }
+
+    #[inline]
     fn shard_for<Q>(
         &self,
         key: &Q,


### PR DESCRIPTION
## Overview

Exposes a `shard_index` method on the `Cache` struct, allowing callers to determine which internal shard a given key maps to.

## Motivation

Users who want to observe key distribution or batch operations against the same shard currently have no way to do this without re-implementing the shard selection logic themselves.

## Changes

- Add `pub fn shard_index<Q: Hash + ?Sized>(&self, key: &Q) -> usize` to `Cache`
- Extract private `compute_shard_index(&self, hash: u64)` helper to deduplicate the rotate+mask logic shared with `shard_for`
- The returned index is guaranteed to be in `[0, num_shards())`

## Use cases

- **Key distribution analysis** — check that keys spread evenly across shards
- **Partitioning** — being able to partition keys by shard

## Notes

- The shard mapping depends on the `BuildHasher` supplied at construction; two caches built with different hashers may map the same key to different shards.
- `?Sized` bound allows calling with unsized types (`str`, `[u8]`) consistent with all other key-taking methods.