### PR TITLE
Improve LockContention ergonomics and move lifecycle init outside shard lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Lightweight and high performance concurrent cache optimized for low cache overhe
 * Scales well with the number of threads
 * Atomic operations with `get_or_insert` and `get_value_or_guard` functions
 * Atomic async operations with `get_or_insert_async` and `get_value_or_guard_async` functions
+* Non-blocking `try_get`, `try_insert`, `try_remove`, and related methods that return an error instead of blocking: typically `Err(LockContention)`, or `Err((Key, Val))` for `try_insert`/`try_insert_with_lifecycle` so inputs are preserved
 * Closure-based `entry` API for atomic inspect-and-act patterns (keep, remove, replace)
 * Supports item pinning
 * Iteration and draining

--- a/src/rw_lock.rs
+++ b/src/rw_lock.rs
@@ -105,6 +105,46 @@ impl<T: ?Sized> RwLock<T> {
         })
     }
 
+    /// Attempts to acquire this `RwLock` with shared read access without blocking.
+    ///
+    /// Returns `Some(guard)` if the lock was acquired, or `None` if it is already
+    /// held by a writer.
+    #[inline]
+    pub fn try_read(&self) -> Option<RwLockReadGuard<'_, T>> {
+        #[cfg(feature = "parking_lot")]
+        {
+            self.0.try_read().map(RwLockReadGuard)
+        }
+        #[cfg(not(feature = "parking_lot"))]
+        {
+            match self.0.try_read() {
+                Ok(guard) => Some(RwLockReadGuard(guard)),
+                Err(std::sync::TryLockError::WouldBlock) => None,
+                Err(std::sync::TryLockError::Poisoned(err)) => panic!("{}", err),
+            }
+        }
+    }
+
+    /// Attempts to acquire this `RwLock` with exclusive write access without blocking.
+    ///
+    /// Returns `Some(guard)` if the lock was acquired, or `None` if it is already
+    /// held by any readers or a writer.
+    #[inline]
+    pub fn try_write(&self) -> Option<RwLockWriteGuard<'_, T>> {
+        #[cfg(feature = "parking_lot")]
+        {
+            self.0.try_write().map(RwLockWriteGuard)
+        }
+        #[cfg(not(feature = "parking_lot"))]
+        {
+            match self.0.try_write() {
+                Ok(guard) => Some(RwLockWriteGuard(guard)),
+                Err(std::sync::TryLockError::WouldBlock) => None,
+                Err(std::sync::TryLockError::Poisoned(err)) => panic!("{}", err),
+            }
+        }
+    }
+
     /// Locks this `RwLock` with exclusive write access, blocking the current
     /// thread until it can be acquired.
     ///

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -18,6 +18,29 @@ use crate::shard::EntryOrPlaceholder;
 pub use crate::sync_placeholder::{EntryAction, EntryResult, GuardResult, PlaceholderGuard};
 use crate::sync_placeholder::{JoinFuture, JoinResult};
 
+/// The result of a non-blocking cache operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContendedResult<Val> {
+    /// The operation succeeded. For read operations the inner value holds the lookup result;
+    /// for write operations it holds the lifecycle request state (or `()` for [`Cache::try_insert`]).
+    Ok(Val),
+    /// The shard lock could not be acquired without blocking. The operation was not performed.
+    Contended,
+}
+
+impl<Val> ContendedResult<Val> {
+    pub fn ok(self) -> Option<Val> {
+        match self {
+            ContendedResult::Ok(val) => Some(val),
+            ContendedResult::Contended => None,
+        }
+    }
+
+    pub fn is_contended(&self) -> bool {
+        matches!(self, ContendedResult::Contended)
+    }
+}
+
 /// A concurrent cache
 ///
 /// The concurrent cache is internally composed of equally sized shards, each of which is independently
@@ -247,6 +270,23 @@ impl<
             .is_some_and(|(shard, hash)| shard.read().contains(hash, key))
     }
 
+    /// Attempts to check if a key exists in the cache without blocking.
+    /// Returns [`ContendedResult::Ok(true)`] if present, [`ContendedResult::Ok(false)`] if absent,
+    /// or [`ContendedResult::Contended`] if the shard lock could not be acquired without blocking.
+    pub fn try_contains_key<Q>(&self, key: &Q) -> ContendedResult<bool>
+    where
+        Q: Hash + Equivalent<Key> + ?Sized,
+    {
+        let Some((shard, hash)) = self.shard_for(key) else {
+            return ContendedResult::Ok(false);
+        };
+
+        shard
+            .try_read()
+            .map(|guard| ContendedResult::Ok(guard.contains(hash, key)))
+            .unwrap_or(ContendedResult::Contended)
+    }
+
     /// Fetches an item from the cache whose key is `key`.
     pub fn get<Q>(&self, key: &Q) -> Option<Val>
     where
@@ -254,6 +294,22 @@ impl<
     {
         let (shard, hash) = self.shard_for(key)?;
         shard.read().get(hash, key).cloned()
+    }
+
+    /// Attempts to fetch an item from the cache whose key is `key`.
+    /// Returns [`ContendedResult::Ok(Some(val))`] if the key is present, [`ContendedResult::Ok(None)`] if absent,
+    /// or [`ContendedResult::Contended`] if the shard lock could not be acquired without blocking.
+    pub fn try_get<Q>(&self, key: &Q) -> ContendedResult<Option<Val>>
+    where
+        Q: Hash + Equivalent<Key> + ?Sized,
+    {
+        let Some((shard, hash)) = self.shard_for(key) else {
+            return ContendedResult::Ok(None);
+        };
+        shard
+            .try_read()
+            .map(|guard| ContendedResult::Ok(guard.get(hash, key).cloned()))
+            .unwrap_or(ContendedResult::Contended)
     }
 
     /// Peeks an item from the cache whose key is `key`.
@@ -266,6 +322,23 @@ impl<
         shard.read().peek(hash, key).cloned()
     }
 
+    /// Attempts to peek an item from the cache whose key is `key`.
+    /// Contrary to gets, peeks don't alter the key "hotness".
+    /// Returns [`ContendedResult::Ok(Some(val))`] if the key is present, [`ContendedResult::Ok(None)`] if absent,
+    /// or [`ContendedResult::Contended`] if the shard lock could not be acquired without blocking.
+    pub fn try_peek<Q>(&self, key: &Q) -> ContendedResult<Option<Val>>
+    where
+        Q: Hash + Equivalent<Key> + ?Sized,
+    {
+        let Some((shard, hash)) = self.shard_for(key) else {
+            return ContendedResult::Ok(None);
+        };
+        shard
+            .try_read()
+            .map(|guard| ContendedResult::Ok(guard.peek(hash, key).cloned()))
+            .unwrap_or(ContendedResult::Contended)
+    }
+
     /// Remove an item from the cache whose key is `key`.
     /// Returns the removed entry, if any.
     pub fn remove<Q>(&self, key: &Q) -> Option<(Key, Val)>
@@ -274,6 +347,23 @@ impl<
     {
         let (shard, hash) = self.shard_for(key).unwrap();
         shard.write().remove(hash, key)
+    }
+
+    /// Attempts to remove an item from the cache whose key is `key`.
+    /// Returns [`ContendedResult::Ok(Some(entry))`] with the removed entry if present, [`ContendedResult::Ok(None)`] if absent,
+    /// or [`ContendedResult::Contended`] if the shard lock could not be acquired without blocking.
+    pub fn try_remove<Q>(&self, key: &Q) -> ContendedResult<Option<(Key, Val)>>
+    where
+        Q: Hash + Equivalent<Key> + ?Sized,
+    {
+        let Some((shard, hash)) = self.shard_for(key) else {
+            return ContendedResult::Ok(None);
+        };
+
+        shard
+            .try_write()
+            .map(|mut guard| ContendedResult::Ok(guard.remove(hash, key)))
+            .unwrap_or(ContendedResult::Contended)
     }
 
     /// Remove an item from the cache whose key is `key` if `f(&value)` returns `true` for that entry.
@@ -337,6 +427,18 @@ impl<
         self.lifecycle.end_request(lcs);
     }
 
+    /// Attempts to insert an item in the cache with key `key`.
+    /// Returns [`ContendedResult::Ok`] if the item was inserted, or [`ContendedResult::Contended`] if the shard lock was contended.
+    pub fn try_insert(&self, key: Key, value: Val) -> ContendedResult<()> {
+        match self.try_insert_with_lifecycle(key, value) {
+            ContendedResult::Ok(lcs) => {
+                self.lifecycle.end_request(lcs);
+                ContendedResult::Ok(())
+            }
+            ContendedResult::Contended => ContendedResult::Contended,
+        }
+    }
+
     /// Inserts an item in the cache with key `key`.
     pub fn insert_with_lifecycle(&self, key: Key, value: Val) -> L::RequestState {
         let mut lcs = self.lifecycle.begin_request();
@@ -347,6 +449,28 @@ impl<
         // result cannot err with the Insert strategy
         debug_assert!(result.is_ok());
         lcs
+    }
+
+    /// Attempts to insert an item in the cache with key `key`.
+    /// Returns [`ContendedResult::Ok`] with the lifecycle request state if the item was inserted,
+    /// or [`ContendedResult::Contended`] if the shard lock was contended.
+    pub fn try_insert_with_lifecycle(
+        &self,
+        key: Key,
+        value: Val,
+    ) -> ContendedResult<L::RequestState> {
+        let (shard, hash) = self.shard_for(&key).unwrap();
+
+        shard
+            .try_write()
+            .map(|mut guard| {
+                let mut lcs = self.lifecycle.begin_request();
+                let result = guard.insert(&mut lcs, hash, key, value, InsertStrategy::Insert);
+                // result cannot err with the Insert strategy
+                debug_assert!(result.is_ok());
+                ContendedResult::Ok(lcs)
+            })
+            .unwrap_or(ContendedResult::Contended)
     }
 
     /// Clear all items from the cache
@@ -1498,5 +1622,134 @@ mod tests {
                 assert_eq!(v, key * 10);
             }
         }
+    }
+
+    // --- Non-blocking method tests ---
+
+    #[test]
+    fn test_contended_result_helpers() {
+        let ok: ContendedResult<i32> = ContendedResult::Ok(42);
+        assert!(!ok.is_contended());
+        assert_eq!(ok.ok(), Some(42));
+
+        let contended: ContendedResult<i32> = ContendedResult::Contended;
+        assert!(contended.is_contended());
+        assert_eq!(contended.ok(), None);
+    }
+
+    #[test]
+    fn test_try_contains_key() {
+        let cache = Cache::new(100);
+        cache.insert(1, 10);
+
+        assert_eq!(cache.try_contains_key(&1), ContendedResult::Ok(true));
+        assert_eq!(cache.try_contains_key(&2), ContendedResult::Ok(false));
+    }
+
+    #[test]
+    fn test_try_contains_key_contended() {
+        let cache = Cache::new(100);
+        cache.insert(1, 10);
+        // Hold write locks on all shards so try_read is blocked.
+        let _guards: Vec<_> = cache.shards.iter().map(|s| s.write()).collect();
+        assert_eq!(cache.try_contains_key(&1), ContendedResult::Contended);
+    }
+
+    #[test]
+    fn test_try_get() {
+        let cache = Cache::new(100);
+        cache.insert(1, 10);
+
+        assert_eq!(cache.try_get(&1), ContendedResult::Ok(Some(10)));
+        assert_eq!(cache.try_get(&2), ContendedResult::Ok(None));
+    }
+
+    #[test]
+    fn test_try_get_contended() {
+        let cache = Cache::new(100);
+        cache.insert(1, 10);
+        let _guards: Vec<_> = cache.shards.iter().map(|s| s.write()).collect();
+        assert_eq!(cache.try_get(&1), ContendedResult::Contended);
+    }
+
+    #[test]
+    fn test_try_peek() {
+        let cache = Cache::new(100);
+        cache.insert(1, 10);
+
+        assert_eq!(cache.try_peek(&1), ContendedResult::Ok(Some(10)));
+        assert_eq!(cache.try_peek(&2), ContendedResult::Ok(None));
+    }
+
+    #[test]
+    fn test_try_peek_contended() {
+        let cache = Cache::new(100);
+        cache.insert(1, 10);
+        let _guards: Vec<_> = cache.shards.iter().map(|s| s.write()).collect();
+        assert_eq!(cache.try_peek(&1), ContendedResult::Contended);
+    }
+
+    #[test]
+    fn test_try_remove() {
+        let cache = Cache::new(100);
+        cache.insert(1, 10);
+
+        assert_eq!(cache.try_remove(&1), ContendedResult::Ok(Some((1, 10))));
+        assert_eq!(cache.try_remove(&1), ContendedResult::Ok(None));
+        assert_eq!(cache.try_remove(&99), ContendedResult::Ok(None));
+    }
+
+    #[test]
+    fn test_try_remove_contended() {
+        let cache = Cache::new(100);
+        cache.insert(1, 10);
+        // Hold read locks on all shards so try_write is blocked.
+        let guards: Vec<_> = cache.shards.iter().map(|s| s.read()).collect();
+        assert_eq!(cache.try_remove(&1), ContendedResult::Contended);
+        drop(guards);
+        // Item must still be present since the remove did not happen.
+        assert_eq!(cache.get(&1), Some(10));
+    }
+
+    #[test]
+    fn test_try_insert() {
+        let cache = Cache::new(100);
+
+        assert_eq!(cache.try_insert(1, 10), ContendedResult::Ok(()));
+        assert_eq!(cache.get(&1), Some(10));
+
+        // Insert same key overwrites the previous value.
+        assert_eq!(cache.try_insert(1, 20), ContendedResult::Ok(()));
+        assert_eq!(cache.get(&1), Some(20));
+    }
+
+    #[test]
+    fn test_try_insert_contended() {
+        let cache = Cache::new(100);
+        let guards: Vec<_> = cache.shards.iter().map(|s| s.read()).collect();
+        assert_eq!(cache.try_insert(1, 10), ContendedResult::Contended);
+        drop(guards);
+        assert_eq!(cache.get(&1), None);
+    }
+
+    #[test]
+    fn test_try_insert_with_lifecycle() {
+        let cache = Cache::new(100);
+
+        // Successful insert returns the lifecycle request state.
+        let result = cache.try_insert_with_lifecycle(1, 10);
+        assert!(!result.is_contended());
+        let lcs = result.ok().unwrap();
+        cache.lifecycle.end_request(lcs);
+        assert_eq!(cache.get(&1), Some(10));
+
+        // Contended when a read lock is held.
+        let guards: Vec<_> = cache.shards.iter().map(|s| s.read()).collect();
+        assert_eq!(
+            cache.try_insert_with_lifecycle(2, 20),
+            ContendedResult::Contended
+        );
+        drop(guards);
+        assert_eq!(cache.get(&2), None);
     }
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -18,28 +18,21 @@ use crate::shard::EntryOrPlaceholder;
 pub use crate::sync_placeholder::{EntryAction, EntryResult, GuardResult, PlaceholderGuard};
 use crate::sync_placeholder::{JoinFuture, JoinResult};
 
-/// The result of a non-blocking cache operation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ContendedResult<Val> {
-    /// The operation succeeded. For read operations the inner value holds the lookup result;
-    /// for write operations it holds the lifecycle request state (or `()` for [`Cache::try_insert`]).
-    Ok(Val),
-    /// The shard lock could not be acquired without blocking. The operation was not performed.
-    Contended,
-}
+/// Error returned by non-blocking cache operations that do not consume their
+/// inputs when the relevant shard lock could not be acquired immediately.
+///
+/// This is used by borrowed-key/read-path operations. Non-blocking operations
+/// that consume owned inputs may instead return those inputs on contention.
+#[derive(Debug)]
+pub struct LockContention;
 
-impl<Val> ContendedResult<Val> {
-    pub fn ok(self) -> Option<Val> {
-        match self {
-            ContendedResult::Ok(val) => Some(val),
-            ContendedResult::Contended => None,
-        }
-    }
-
-    pub fn is_contended(&self) -> bool {
-        matches!(self, ContendedResult::Contended)
+impl std::fmt::Display for LockContention {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Lock Contention")
     }
 }
+
+impl std::error::Error for LockContention {}
 
 /// A concurrent cache
 ///
@@ -298,20 +291,20 @@ impl<
     }
 
     /// Attempts to check if a key exists in the cache without blocking.
-    /// Returns [`ContendedResult::Ok(true)`] if present, [`ContendedResult::Ok(false)`] if absent,
-    /// or [`ContendedResult::Contended`] if the shard lock could not be acquired without blocking.
-    pub fn try_contains_key<Q>(&self, key: &Q) -> ContendedResult<bool>
+    /// Returns `Ok(true)` if present, `Ok(false)` if absent,
+    /// or `Err(LockContention)` if the shard lock could not be acquired without blocking.
+    pub fn try_contains_key<Q>(&self, key: &Q) -> Result<bool, LockContention>
     where
         Q: Hash + Equivalent<Key> + ?Sized,
     {
         let Some((shard, hash)) = self.shard_for(key) else {
-            return ContendedResult::Ok(false);
+            return Ok(false);
         };
 
-        shard
-            .try_read()
-            .map(|guard| ContendedResult::Ok(guard.contains(hash, key)))
-            .unwrap_or(ContendedResult::Contended)
+        match shard.try_read() {
+            Some(guard) => Ok(guard.contains(hash, key)),
+            None => Err(LockContention),
+        }
     }
 
     /// Fetches an item from the cache whose key is `key`.
@@ -324,19 +317,20 @@ impl<
     }
 
     /// Attempts to fetch an item from the cache whose key is `key`.
-    /// Returns [`ContendedResult::Ok(Some(val))`] if the key is present, [`ContendedResult::Ok(None)`] if absent,
-    /// or [`ContendedResult::Contended`] if the shard lock could not be acquired without blocking.
-    pub fn try_get<Q>(&self, key: &Q) -> ContendedResult<Option<Val>>
+    /// Returns `Ok(Some(val))` if the key is present, `Ok(None)` if absent,
+    /// or `Err(LockContention)` if the shard lock could not be acquired without blocking.
+    pub fn try_get<Q>(&self, key: &Q) -> Result<Option<Val>, LockContention>
     where
         Q: Hash + Equivalent<Key> + ?Sized,
     {
         let Some((shard, hash)) = self.shard_for(key) else {
-            return ContendedResult::Ok(None);
+            return Ok(None);
         };
-        shard
-            .try_read()
-            .map(|guard| ContendedResult::Ok(guard.get(hash, key).cloned()))
-            .unwrap_or(ContendedResult::Contended)
+
+        match shard.try_read() {
+            Some(guard) => Ok(guard.get(hash, key).cloned()),
+            None => Err(LockContention),
+        }
     }
 
     /// Peeks an item from the cache whose key is `key`.
@@ -351,19 +345,19 @@ impl<
 
     /// Attempts to peek an item from the cache whose key is `key`.
     /// Contrary to gets, peeks don't alter the key "hotness".
-    /// Returns [`ContendedResult::Ok(Some(val))`] if the key is present, [`ContendedResult::Ok(None)`] if absent,
-    /// or [`ContendedResult::Contended`] if the shard lock could not be acquired without blocking.
-    pub fn try_peek<Q>(&self, key: &Q) -> ContendedResult<Option<Val>>
+    /// Returns `Ok(Some(val))` if the key is present, `Ok(None)` if absent,
+    /// or `Err(LockContention)` if the shard lock could not be acquired without blocking.
+    pub fn try_peek<Q>(&self, key: &Q) -> Result<Option<Val>, LockContention>
     where
         Q: Hash + Equivalent<Key> + ?Sized,
     {
         let Some((shard, hash)) = self.shard_for(key) else {
-            return ContendedResult::Ok(None);
+            return Ok(None);
         };
-        shard
-            .try_read()
-            .map(|guard| ContendedResult::Ok(guard.peek(hash, key).cloned()))
-            .unwrap_or(ContendedResult::Contended)
+        match shard.try_read() {
+            Some(guard) => Ok(guard.peek(hash, key).cloned()),
+            None => Err(LockContention),
+        }
     }
 
     /// Remove an item from the cache whose key is `key`.
@@ -377,20 +371,20 @@ impl<
     }
 
     /// Attempts to remove an item from the cache whose key is `key`.
-    /// Returns [`ContendedResult::Ok(Some(entry))`] with the removed entry if present, [`ContendedResult::Ok(None)`] if absent,
-    /// or [`ContendedResult::Contended`] if the shard lock could not be acquired without blocking.
-    pub fn try_remove<Q>(&self, key: &Q) -> ContendedResult<Option<(Key, Val)>>
+    /// Returns `Ok(Some(entry))` with the removed entry if present, `Ok(None)` if absent,
+    /// or `Err(LockContention)` if the shard lock could not be acquired without blocking.
+    pub fn try_remove<Q>(&self, key: &Q) -> Result<Option<(Key, Val)>, LockContention>
     where
         Q: Hash + Equivalent<Key> + ?Sized,
     {
         let Some((shard, hash)) = self.shard_for(key) else {
-            return ContendedResult::Ok(None);
+            return Ok(None);
         };
 
-        shard
-            .try_write()
-            .map(|mut guard| ContendedResult::Ok(guard.remove(hash, key)))
-            .unwrap_or(ContendedResult::Contended)
+        match shard.try_write() {
+            Some(mut guard) => Ok(guard.remove(hash, key)),
+            None => Err(LockContention),
+        }
     }
 
     /// Remove an item from the cache whose key is `key` if `f(&value)` returns `true` for that entry.
@@ -454,16 +448,13 @@ impl<
         self.lifecycle.end_request(lcs);
     }
 
-    /// Attempts to insert an item in the cache with key `key`.
-    /// Returns [`ContendedResult::Ok`] if the item was inserted, or [`ContendedResult::Contended`] if the shard lock was contended.
-    pub fn try_insert(&self, key: Key, value: Val) -> ContendedResult<()> {
-        match self.try_insert_with_lifecycle(key, value) {
-            ContendedResult::Ok(lcs) => {
-                self.lifecycle.end_request(lcs);
-                ContendedResult::Ok(())
-            }
-            ContendedResult::Contended => ContendedResult::Contended,
-        }
+    /// Attempts to insert an item in the cache with key `key` without blocking.
+    /// Returns `Ok(())` if the item was inserted, or `Err((key, value))` if the shard lock
+    /// could not be acquired without blocking.
+    pub fn try_insert(&self, key: Key, value: Val) -> Result<(), (Key, Val)> {
+        let lcs = self.try_insert_with_lifecycle(key, value)?;
+        self.lifecycle.end_request(lcs);
+        Ok(())
     }
 
     /// Inserts an item in the cache with key `key`.
@@ -478,26 +469,26 @@ impl<
         lcs
     }
 
-    /// Attempts to insert an item in the cache with key `key`.
-    /// Returns [`ContendedResult::Ok`] with the lifecycle request state if the item was inserted,
-    /// or [`ContendedResult::Contended`] if the shard lock was contended.
+    /// Attempts to insert an item in the cache with key `key` without blocking.
+    /// Returns `Ok(lcs)` with the lifecycle request state if the item was inserted,
+    /// or `Err((key, value))` if the shard lock could not be acquired without blocking.
     pub fn try_insert_with_lifecycle(
         &self,
         key: Key,
         value: Val,
-    ) -> ContendedResult<L::RequestState> {
+    ) -> Result<L::RequestState, (Key, Val)> {
         let (shard, hash) = self.shard_for(&key).unwrap();
 
-        shard
-            .try_write()
-            .map(|mut guard| {
+        match shard.try_write() {
+            Some(mut shard) => {
                 let mut lcs = self.lifecycle.begin_request();
-                let result = guard.insert(&mut lcs, hash, key, value, InsertStrategy::Insert);
+                let result = shard.insert(&mut lcs, hash, key, value, InsertStrategy::Insert);
                 // result cannot err with the Insert strategy
                 debug_assert!(result.is_ok());
-                ContendedResult::Ok(lcs)
-            })
-            .unwrap_or(ContendedResult::Contended)
+                Ok(lcs)
+            }
+            _ => Err((key, value)),
+        }
     }
 
     /// Clear all items from the cache
@@ -1652,25 +1643,13 @@ mod tests {
     }
 
     // --- Non-blocking method tests ---
-
-    #[test]
-    fn test_contended_result_helpers() {
-        let ok: ContendedResult<i32> = ContendedResult::Ok(42);
-        assert!(!ok.is_contended());
-        assert_eq!(ok.ok(), Some(42));
-
-        let contended: ContendedResult<i32> = ContendedResult::Contended;
-        assert!(contended.is_contended());
-        assert_eq!(contended.ok(), None);
-    }
-
     #[test]
     fn test_try_contains_key() {
         let cache = Cache::new(100);
         cache.insert(1, 10);
 
-        assert_eq!(cache.try_contains_key(&1), ContendedResult::Ok(true));
-        assert_eq!(cache.try_contains_key(&2), ContendedResult::Ok(false));
+        assert!(cache.try_contains_key(&1).is_ok_and(|v| v));
+        assert!(cache.try_contains_key(&2).is_ok_and(|v| !v));
     }
 
     #[test]
@@ -1679,7 +1658,7 @@ mod tests {
         cache.insert(1, 10);
         // Hold write locks on all shards so try_read is blocked.
         let _guards: Vec<_> = cache.shards.iter().map(|s| s.write()).collect();
-        assert_eq!(cache.try_contains_key(&1), ContendedResult::Contended);
+        assert!(cache.try_contains_key(&1).is_err());
     }
 
     #[test]
@@ -1687,8 +1666,8 @@ mod tests {
         let cache = Cache::new(100);
         cache.insert(1, 10);
 
-        assert_eq!(cache.try_get(&1), ContendedResult::Ok(Some(10)));
-        assert_eq!(cache.try_get(&2), ContendedResult::Ok(None));
+        assert!(cache.try_get(&1).is_ok_and(|v| matches!(v, Some(10))));
+        assert!(cache.try_get(&2).is_ok_and(|v| v.is_none()));
     }
 
     #[test]
@@ -1696,7 +1675,7 @@ mod tests {
         let cache = Cache::new(100);
         cache.insert(1, 10);
         let _guards: Vec<_> = cache.shards.iter().map(|s| s.write()).collect();
-        assert_eq!(cache.try_get(&1), ContendedResult::Contended);
+        assert!(cache.try_get(&1).is_err());
     }
 
     #[test]
@@ -1704,8 +1683,8 @@ mod tests {
         let cache = Cache::new(100);
         cache.insert(1, 10);
 
-        assert_eq!(cache.try_peek(&1), ContendedResult::Ok(Some(10)));
-        assert_eq!(cache.try_peek(&2), ContendedResult::Ok(None));
+        assert!(cache.try_peek(&1).is_ok_and(|v| matches!(v, Some(10))));
+        assert!(cache.try_peek(&2).is_ok_and(|v| v.is_none()));
     }
 
     #[test]
@@ -1713,7 +1692,7 @@ mod tests {
         let cache = Cache::new(100);
         cache.insert(1, 10);
         let _guards: Vec<_> = cache.shards.iter().map(|s| s.write()).collect();
-        assert_eq!(cache.try_peek(&1), ContendedResult::Contended);
+        assert!(cache.try_peek(&1).is_err());
     }
 
     #[test]
@@ -1721,9 +1700,11 @@ mod tests {
         let cache = Cache::new(100);
         cache.insert(1, 10);
 
-        assert_eq!(cache.try_remove(&1), ContendedResult::Ok(Some((1, 10))));
-        assert_eq!(cache.try_remove(&1), ContendedResult::Ok(None));
-        assert_eq!(cache.try_remove(&99), ContendedResult::Ok(None));
+        assert!(cache
+            .try_remove(&1)
+            .is_ok_and(|v| matches!(v, Some((1, 10)))));
+        assert!(cache.try_remove(&1).is_ok_and(|v| v.is_none()));
+        assert!(cache.try_remove(&99).is_ok_and(|v| v.is_none()));
     }
 
     #[test]
@@ -1732,7 +1713,7 @@ mod tests {
         cache.insert(1, 10);
         // Hold read locks on all shards so try_write is blocked.
         let guards: Vec<_> = cache.shards.iter().map(|s| s.read()).collect();
-        assert_eq!(cache.try_remove(&1), ContendedResult::Contended);
+        assert!(cache.try_remove(&1).is_err());
         drop(guards);
         // Item must still be present since the remove did not happen.
         assert_eq!(cache.get(&1), Some(10));
@@ -1742,11 +1723,11 @@ mod tests {
     fn test_try_insert() {
         let cache = Cache::new(100);
 
-        assert_eq!(cache.try_insert(1, 10), ContendedResult::Ok(()));
+        assert_eq!(cache.try_insert(1, 10), Ok(()));
         assert_eq!(cache.get(&1), Some(10));
 
         // Insert same key overwrites the previous value.
-        assert_eq!(cache.try_insert(1, 20), ContendedResult::Ok(()));
+        assert_eq!(cache.try_insert(1, 20), Ok(()));
         assert_eq!(cache.get(&1), Some(20));
     }
 
@@ -1754,7 +1735,7 @@ mod tests {
     fn test_try_insert_contended() {
         let cache = Cache::new(100);
         let guards: Vec<_> = cache.shards.iter().map(|s| s.read()).collect();
-        assert_eq!(cache.try_insert(1, 10), ContendedResult::Contended);
+        assert_eq!(cache.try_insert(1, 10), Err((1, 10)));
         drop(guards);
         assert_eq!(cache.get(&1), None);
     }
@@ -1765,17 +1746,14 @@ mod tests {
 
         // Successful insert returns the lifecycle request state.
         let result = cache.try_insert_with_lifecycle(1, 10);
-        assert!(!result.is_contended());
+        assert!(result.is_ok());
         let lcs = result.ok().unwrap();
         cache.lifecycle.end_request(lcs);
         assert_eq!(cache.get(&1), Some(10));
 
         // Contended when a read lock is held.
         let guards: Vec<_> = cache.shards.iter().map(|s| s.read()).collect();
-        assert_eq!(
-            cache.try_insert_with_lifecycle(2, 20),
-            ContendedResult::Contended
-        );
+        assert_eq!(cache.try_insert_with_lifecycle(2, 20), Err((2, 20)));
         drop(guards);
         assert_eq!(cache.get(&2), None);
     }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -232,6 +232,37 @@ impl<
     }
 
     #[inline]
+    fn compute_shard_index(&self, hash: u64) -> u64 {
+        // Give preference to the bits in the middle of the hash. When choosing the
+        // shard, rotate the hash by usize::BITS / 2 so we avoid the lower bits and
+        // the highest 7 bits that hashbrown uses internally for probing, improving
+        // the real entropy available to each hashbrown shard.
+        hash.rotate_right(usize::BITS / 2) & self.shards_mask
+    }
+
+    /// Returns the shard index for the given key.
+    ///
+    /// The returned index is guaranteed to be in `[0, num_shards())`.
+    ///
+    /// # Use cases
+    ///
+    /// - **Batching**: group keys by shard index before acquiring shard locks, so
+    ///   each lock is taken only once per batch instead of once per key.
+    ///
+    /// # Notes
+    ///
+    /// The mapping from key to shard index depends on the [`BuildHasher`] supplied
+    /// at construction time. If two `Cache` instances are built with different
+    /// hashers, the same key may map to different shard indices.
+    ///
+    /// [`BuildHasher`]: std::hash::BuildHasher
+    #[inline]
+    pub fn shard_index<Q: Hash + Equivalent<Key> + ?Sized>(&self, key: &Q) -> usize {
+        let hash = self.hash_builder.hash_one(key);
+        self.compute_shard_index(hash) as usize
+    }
+
+    #[inline]
     fn shard_for<Q>(
         &self,
         key: &Q,
@@ -243,11 +274,7 @@ impl<
         Q: Hash + Equivalent<Key> + ?Sized,
     {
         let hash = self.hash_builder.hash_one(key);
-        // When choosing the shard, rotate the hash bits usize::BITS / 2 so that we
-        // give preference to the bits in the middle of the hash.
-        // Internally hashbrown uses the lower bits for start of probing + the 7 highest,
-        // so by picking something else we improve the real entropy available to each hashbrown shard.
-        let shard_idx = (hash.rotate_right(usize::BITS / 2) & self.shards_mask) as usize;
+        let shard_idx = self.compute_shard_index(hash) as usize;
         self.shards.get(shard_idx).map(|s| (s, hash))
     }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -22,8 +22,9 @@ use crate::sync_placeholder::{JoinFuture, JoinResult};
 /// inputs when the relevant shard lock could not be acquired immediately.
 ///
 /// This is used by borrowed-key/read-path operations. Non-blocking operations
-/// that consume owned inputs may instead return those inputs on contention.
-#[derive(Debug)]
+/// that consume owned inputs (e.g. `try_insert`) instead return those inputs
+/// on contention so the caller can retry or discard without losing data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct LockContention;
 
 impl std::fmt::Display for LockContention {
@@ -450,7 +451,8 @@ impl<
 
     /// Attempts to insert an item in the cache with key `key` without blocking.
     /// Returns `Ok(())` if the item was inserted, or `Err((key, value))` if the shard lock
-    /// could not be acquired without blocking.
+    /// could not be acquired without blocking. Lock contention is the only failure
+    /// mode: the inputs are returned so the caller can retry or discard them.
     pub fn try_insert(&self, key: Key, value: Val) -> Result<(), (Key, Val)> {
         let lcs = self.try_insert_with_lifecycle(key, value)?;
         self.lifecycle.end_request(lcs);
@@ -472,16 +474,20 @@ impl<
     /// Attempts to insert an item in the cache with key `key` without blocking.
     /// Returns `Ok(lcs)` with the lifecycle request state if the item was inserted,
     /// or `Err((key, value))` if the shard lock could not be acquired without blocking.
+    /// Lock contention is the only failure mode: the inputs are returned so the
+    /// caller can retry or discard them.
     pub fn try_insert_with_lifecycle(
         &self,
         key: Key,
         value: Val,
     ) -> Result<L::RequestState, (Key, Val)> {
+        // Tradeoff: begin_request is called before acquiring the shard lock to avoid holding
+        // the lock during potentially expensive lifecycle initialization.
+        let mut lcs = self.lifecycle.begin_request();
         let (shard, hash) = self.shard_for(&key).unwrap();
 
         match shard.try_write() {
             Some(mut shard) => {
-                let mut lcs = self.lifecycle.begin_request();
                 let result = shard.insert(&mut lcs, hash, key, value, InsertStrategy::Insert);
                 // result cannot err with the Insert strategy
                 debug_assert!(result.is_ok());


### PR DESCRIPTION
## Summary

- **`LockContention` ergonomics**: Added `Clone, Copy, PartialEq, Eq, Hash` derives so the error type can be compared, stored in sets/maps, and used in more contexts without surprise.
- **Performance fix in `try_insert_with_lifecycle`**: Moved `lifecycle.begin_request()` to before the shard lock is acquired. Previously the lifecycle was initialized while holding the write lock; moving it outside avoids blocking other operations on the same shard during potentially expensive lifecycle setup.
- **Doc improvements**: Clarified that lock contention is the only failure mode for `try_insert` / `try_insert_with_lifecycle`, and that inputs are returned so callers can retry or discard without data loss.

## Test plan

- [ ] Existing tests pass (`cargo test`)
- [ ] `test_try_insert` and `test_try_insert_with_lifecycle` cover the non-blocking insert paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)