### PR TITLE
Return `Resident` struct from `iter` and `iter_mut`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,7 @@ mod options;
 #[cfg(not(feature = "shuttle"))]
 mod rw_lock;
 mod shard;
+pub use shard::{Resident, ResidentState};
 mod shim;
 /// Concurrent cache variants that can be used from multiple threads.
 pub mod sync;

--- a/src/shard.rs
+++ b/src/shard.rs
@@ -68,16 +68,16 @@ pub enum EntryOrPlaceholder<Key, Val, Plh, T> {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-enum ResidentState {
+pub enum ResidentState {
     Hot,
     Cold,
 }
 
 #[derive(Debug)]
 pub struct Resident<Key, Val> {
-    key: Key,
-    value: Val,
-    state: ResidentState,
+    pub key: Key,
+    pub value: Val,
+    pub state: ResidentState,
     referenced: AtomicU16,
 }
 
@@ -297,9 +297,9 @@ impl<Key, Val, We, B, L, Plh> CacheShard<Key, Val, We, B, L, Plh> {
         })
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (&'_ Key, &'_ Val)> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = &'_ Resident<Key, Val>> + '_ {
         self.entries.iter().filter_map(|i| match i {
-            Entry::Resident(r) => Some((&r.key, &r.value)),
+            Entry::Resident(r) => Some(r),
             Entry::Placeholder(_) | Entry::Ghost(_) => None,
         })
     }
@@ -307,11 +307,11 @@ impl<Key, Val, We, B, L, Plh> CacheShard<Key, Val, We, B, L, Plh> {
     pub fn iter_from(
         &self,
         continuation: Option<Token>,
-    ) -> impl Iterator<Item = (Token, &'_ Key, &'_ Val)> + '_ {
+    ) -> impl Iterator<Item = (Token, &'_ Resident<Key, Val>)> + '_ {
         self.entries
             .iter_from(continuation)
             .filter_map(|(token, i)| match i {
-                Entry::Resident(r) => Some((token, &r.key, &r.value)),
+                Entry::Resident(r) => Some((token, r)),
                 Entry::Placeholder(_) | Entry::Ghost(_) => None,
             })
     }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -729,9 +729,9 @@ where
         while self.current_shard < self.shards.len() {
             let shard = &self.shards[self.current_shard];
             let lock = shard.read();
-            if let Some((new_last, key, val)) = lock.iter_from(self.last).next() {
+            if let Some((new_last, r)) = lock.iter_from(self.last).next() {
                 self.last = Some(new_last);
-                return Some((key.clone(), val.clone()));
+                return Some((r.key.clone(), r.value.clone()));
             }
             self.last = None;
             self.current_shard += 1;

--- a/src/unsync.rs
+++ b/src/unsync.rs
@@ -1,7 +1,7 @@
 use crate::{
     linked_slab::Token,
     options::*,
-    shard::{self, CacheShard, InsertStrategy},
+    shard::{self, CacheShard, InsertStrategy, Resident},
     DefaultHashBuilder, Equivalent, Lifecycle, MemoryUsed, UnitWeighter, Weighter,
 };
 use std::hash::{BuildHasher, Hash};
@@ -374,7 +374,7 @@ impl<Key: Eq + Hash, Val, We: Weighter<Key, Val>, B: BuildHasher, L: Lifecycle<K
     }
 
     /// Iterator for the items in the cache
-    pub fn iter(&self) -> impl Iterator<Item = (&'_ Key, &'_ Val)> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = &'_ Resident<Key, Val>> + '_ {
         // TODO: add a concrete type, impl trait in the public api is really bad.
         self.shard.iter()
     }


### PR DESCRIPTION
This would help with #115 indirectly as I could insert to cache twice if `ResidentState` is `Hot`. I could then easily save and restore the cache. I would lose Ghost queue but at least residents would be restored.

This also helps if I need to now what hot items are in my cache if I need to perform some extra operation on them.

Edit: Upon further examining of the code I see the following logic, so if I were to iterate in reverse I would recreate the same cache anyway. My other point about knowing which item is hot or not is still a valid use case though.

https://github.com/arthurprs/quick-cache/blob/8b0077f7d8517fbd3cdc5cef63469d434325c7f1/src/shard.rs#L1085-L1095