### PR TITLE
fix: memory leak in dropping uninserted guard

### DIFF
--- a/src/shard.rs
+++ b/src/shard.rs
@@ -223,8 +223,8 @@ impl<Key, Val, We, B, L, Plh: SharedPlaceholder> CacheShard<Key, Val, We, B, L, 
             matches!(entry, Entry::Placeholder(Placeholder { shared, .. }) if shared.same_as(placeholder))
         }) {
             entry.remove();
+            self.entries.remove(placeholder.idx());
         }
-        self.entries.remove(placeholder.idx());
     }
 
     #[cold]

--- a/src/shard.rs
+++ b/src/shard.rs
@@ -224,6 +224,7 @@ impl<Key, Val, We, B, L, Plh: SharedPlaceholder> CacheShard<Key, Val, We, B, L, 
         }) {
             entry.remove();
         }
+        self.entries.remove(placeholder.idx());
     }
 
     #[cold]

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1782,4 +1782,37 @@ mod tests {
         drop(guard2);
         assert_eq!(idx1, idx2);
     }
+
+    // A real insert overwrites the placeholder in place, reusing its slab slot as
+    // a Resident. Dropping the now-stale guard must not free that slot, otherwise
+    // the live entry is evicted while the map still references it.
+    #[test]
+    fn test_guard_drop_after_overwrite_insert() {
+        let cache: Cache<i32, i32> = Cache::new(8);
+        let guard = match cache.get_value_or_guard(&1, None) {
+            GuardResult::Guard(g) => g,
+            _ => panic!("expected guard"),
+        };
+        cache.insert(1, 100);
+        assert_eq!(cache.get(&1), Some(100));
+        drop(guard);
+        assert_eq!(cache.get(&1), Some(100));
+    }
+
+    // A remove frees the placeholder's slab slot, which a later insert reuses for a
+    // different key. Dropping the original guard must not free that slot again, or
+    // it evicts the unrelated key.
+    #[test]
+    fn test_guard_drop_after_remove_and_reuse() {
+        let cache: Cache<i32, i32> = Cache::new(8);
+        let guard = match cache.get_value_or_guard(&1, None) {
+            GuardResult::Guard(g) => g,
+            _ => panic!("expected guard"),
+        };
+        cache.remove(&1);
+        cache.insert(2, 222);
+        assert_eq!(cache.get(&2), Some(222));
+        drop(guard);
+        assert_eq!(cache.get(&2), Some(222));
+    }
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -958,6 +958,7 @@ impl<Key, Val> Lifecycle<Key, Val> for DefaultLifecycle<Key, Val> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::shard::SharedPlaceholder as _;
     use std::{
         sync::{Arc, Barrier},
         thread,
@@ -1762,5 +1763,23 @@ mod tests {
         assert_eq!(cache.try_insert_with_lifecycle(2, 20), Err((2, 20)));
         drop(guards);
         assert_eq!(cache.get(&2), None);
+    }
+
+    #[test]
+    fn test_guard_leak() {
+        let cache: Cache<i32, i32> = Cache::new(8);
+        let guard1 = match cache.get_value_or_guard(&1, None) {
+            GuardResult::Guard(g) => g,
+            _ => panic!("expected guard"),
+        };
+        let idx1 = guard1.shared().idx();
+        drop(guard1);
+        let guard2 = match cache.get_value_or_guard(&1, None) {
+            GuardResult::Guard(g) => g,
+            _ => panic!("expected guard"),
+        };
+        let idx2 = guard2.shared().idx();
+        drop(guard2);
+        assert_eq!(idx1, idx2);
     }
 }

--- a/src/sync_placeholder.rs
+++ b/src/sync_placeholder.rs
@@ -93,6 +93,13 @@ pub struct PlaceholderGuard<'a, Key, Val, We, B, L> {
     inserted: bool,
 }
 
+#[cfg(test)]
+impl<'a, Key, Val, We, B, L> PlaceholderGuard<'a, Key, Val, We, B, L> {
+    pub fn shared(&self) -> &SharedPlaceholder<Val> {
+        &self.shared
+    }
+}
+
 #[derive(Debug)]
 enum Waiter {
     Thread {


### PR DESCRIPTION
This PR attempts to fix a potential memory leak when dropping uninserted `PlaceholderGuard` instances. Basically, an uninserted `PlaceholderGuard` is not removed from `CacheShard::entries` and cannot be reused for the same key.