### PR TITLE
Fix MSRV build: qualify size_of, add cargo-msrv CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,27 @@ jobs:
       - run: cargo check --all-targets --no-default-features --features sharded-lock
       - run: cargo check --all-targets --features shuttle
 
+  msrv:
+    name: MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-msrv
+      # `cargo msrv verify` checks that the crate compiles with the
+      # `rust-version` declared in Cargo.toml. The default `cargo check` skips
+      # dev-dependencies, which may require a newer Rust than downstream needs.
+      - run: cargo msrv verify
+      - run: cargo msrv verify -- cargo check --features stats
+      - run: cargo msrv verify -- cargo check --no-default-features
+      - run: cargo msrv verify -- cargo check --no-default-features --features sharded-lock
+
   test:
     name: Tests
     strategy:

--- a/src/linked_slab.rs
+++ b/src/linked_slab.rs
@@ -247,6 +247,6 @@ impl<T> LinkedSlab<T> {
     /// It should be noted that if cache key or value is some type like `Vec<T>`,
     /// the memory allocated in the heap will not be counted.
     pub fn memory_used(&self) -> usize {
-        self.entries.len() * size_of::<Entry<T>>()
+        self.entries.len() * std::mem::size_of::<Entry<T>>()
     }
 }


### PR DESCRIPTION
Fixes #118.

## Problem

`std::mem::size_of` was only added to the standard prelude in Rust 1.80, but the declared MSRV is 1.71 (`rust-version = "1.71"` in `Cargo.toml`). It was used unqualified in `linked_slab.rs::memory_used`, so downstream crates on Rust < 1.80 failed to build (reported on 1.75).

## Fix

- Qualify the call as `std::mem::size_of::<Entry<T>>()` (matching the existing usage in `shard.rs`).
- Add an `msrv` CI job that runs `cargo msrv verify`, which checks the crate compiles with the `rust-version` declared in `Cargo.toml`, across the same feature combinations as the existing check job. CI previously only ran on `stable`, which is why this slipped through.

## Verification

Tested locally with `cargo-msrv` 0.19.3 against a real Rust 1.71.0 toolchain:

- `cargo msrv verify` reports **compatible with 1.71.0** for default features, `--features stats`, `--no-default-features`, and `--no-default-features --features sharded-lock`.
- Reverting the one-line fix makes `cargo msrv verify` fail with `E0425` (cannot find `size_of`), confirming the new CI job actually catches this class of regression.